### PR TITLE
Harden crypto, TLS, and memory safety across codebase

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nostr,
-    .version = "0.1.9",
+    .version = "0.2.0",
     .fingerprint = 0x208aa38f708e8e25,
     .dependencies = .{
         .noscrypt = .{

--- a/src/builder.zig
+++ b/src/builder.zig
@@ -20,6 +20,10 @@ pub const Keypair = struct {
             .public_key = public_key,
         };
     }
+
+    pub fn deinit(self: *Keypair) void {
+        std.crypto.secureZero(u8, &self.secret_key);
+    }
 };
 
 pub const EventBuilder = struct {
@@ -101,6 +105,10 @@ pub const EventBuilder = struct {
     }
 
     pub fn mine(self: *EventBuilder, keypair: *const Keypair, target_difficulty: u8) !u64 {
+        return self.mineWithLimit(keypair, target_difficulty, null);
+    }
+
+    pub fn mineWithLimit(self: *EventBuilder, keypair: *const Keypair, target_difficulty: u8, max_iterations: ?u64) !u64 {
         @memcpy(&self.pubkey_bytes, &keypair.public_key);
 
         if (self.created_at_val == 0) {
@@ -142,6 +150,10 @@ pub const EventBuilder = struct {
         const prefix = prefix_fbs.getWritten();
 
         while (true) : (nonce += 1) {
+            if (max_iterations) |limit| {
+                if (nonce >= limit) return error.MiningLimitReached;
+            }
+
             const nonce_str = std.fmt.bufPrint(&nonce_str_buf, "{d}", .{nonce}) catch unreachable;
 
             var hasher = std.crypto.hash.sha2.Sha256.init(.{});

--- a/src/builder.zig
+++ b/src/builder.zig
@@ -11,6 +11,7 @@ pub const Keypair = struct {
     pub fn generate() Keypair {
         var secret_key: [32]u8 = undefined;
         std.crypto.random.bytes(&secret_key);
+        defer std.crypto.secureZero(u8, &secret_key);
 
         var public_key: [32]u8 = undefined;
         crypto.getPublicKey(&secret_key, &public_key) catch unreachable;
@@ -23,6 +24,7 @@ pub const Keypair = struct {
 
     pub fn deinit(self: *Keypair) void {
         std.crypto.secureZero(u8, &self.secret_key);
+        std.crypto.secureZero(u8, &self.public_key);
     }
 };
 

--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -54,12 +54,12 @@ pub fn cleanup() void {
         _ = nc.NCDestroyContext(c);
         ctx = null;
     }
-    initialized = false;
-    init_err = false;
+    @atomicStore(bool, &initialized, false, .release);
+    @atomicStore(bool, &init_err, false, .release);
 }
 
 pub fn verifySignature(pubkey: *const [32]u8, message: *const [32]u8, sig: *const [64]u8) !void {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     const pk = nc.NCByteCastToPublicKey(pubkey);
     const result = nc.NCVerifyDigest(ctx, pk, message, sig);
@@ -70,7 +70,7 @@ pub fn verifySignature(pubkey: *const [32]u8, message: *const [32]u8, sig: *cons
 }
 
 pub fn sign(secret_key: *const [32]u8, message: *const [32]u8, sig_out: *[64]u8) !void {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     const sk = nc.NCByteCastToSecretKey(secret_key);
 
@@ -86,7 +86,7 @@ pub fn sign(secret_key: *const [32]u8, message: *const [32]u8, sig_out: *[64]u8)
 }
 
 pub fn getPublicKey(secret_key: *const [32]u8, pubkey_out: *[32]u8) !void {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     const sk = nc.NCByteCastToSecretKey(secret_key);
     const pk = nc.NCByteCastToPublicKey(pubkey_out);
@@ -99,7 +99,7 @@ pub fn getPublicKey(secret_key: *const [32]u8, pubkey_out: *[32]u8) !void {
 }
 
 pub fn validateSecretKey(secret_key: *const [32]u8) !void {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     const sk = nc.NCByteCastToSecretKey(secret_key);
     const result = nc.NCValidateSecretKey(ctx, sk);
@@ -163,7 +163,7 @@ pub fn nip44Encrypt(
     plaintext: []const u8,
     allocator: std.mem.Allocator,
 ) ![]u8 {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     if (plaintext.len < MIN_PLAINTEXT_SIZE) return Nip44Error.MessageTooSmall;
     if (plaintext.len > MAX_PLAINTEXT_SIZE) return Nip44Error.MessageTooLarge;
@@ -182,6 +182,7 @@ pub fn nip44Encrypt(
     std.crypto.random.bytes(&nonce);
 
     var hmac_key: [32]u8 = undefined;
+    defer std.crypto.secureZero(u8, &hmac_key);
 
     var args: nc.NCEncryptionArgs = .{
         .ivData = &nonce,
@@ -226,7 +227,7 @@ pub fn nip44Decrypt(
     payload: []const u8,
     allocator: std.mem.Allocator,
 ) ![]u8 {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     if (payload.len == 0) return Nip44Error.InvalidPayload;
     if (payload[0] == '#') return Nip44Error.UnsupportedVersion;
@@ -282,7 +283,7 @@ pub fn nip44Decrypt(
 }
 
 pub fn getConversationKey(secret_key: *const [32]u8, pubkey: *const [32]u8, out: *[32]u8) !void {
-    if (!initialized) try init();
+    if (!@atomicLoad(bool, &initialized, .acquire)) try init();
 
     const sk = nc.NCByteCastToSecretKey(secret_key);
     const pk = nc.NCByteCastToPublicKey(pubkey);

--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -7,7 +7,9 @@ const nc = @cImport({
 const NC_SUCCESS: i64 = 0;
 
 var ctx: ?*nc.NCContext = null;
+var init_mutex: std.Thread.Mutex = .{};
 var initialized = false;
+var init_err = false;
 
 pub const CryptoError = error{
     InitFailed,
@@ -17,28 +19,43 @@ pub const CryptoError = error{
 };
 
 pub fn init() !void {
+    if (@atomicLoad(bool, &initialized, .acquire)) return;
+
+    init_mutex.lock();
+    defer init_mutex.unlock();
+
     if (initialized) return;
+    if (init_err) return error.InitFailed;
 
     ctx = nc.NCGetSharedContext();
-    if (ctx == null) return error.InitFailed;
-
-    var entropy: [32]u8 = undefined;
-    std.crypto.random.bytes(&entropy);
-
-    const result = nc.NCInitContext(ctx, &entropy);
-    if (result != NC_SUCCESS) {
+    if (ctx == null) {
+        init_err = true;
         return error.InitFailed;
     }
 
-    initialized = true;
+    var entropy: [32]u8 = undefined;
+    std.crypto.random.bytes(&entropy);
+    defer std.crypto.secureZero(u8, &entropy);
+
+    const result = nc.NCInitContext(ctx, &entropy);
+    if (result != NC_SUCCESS) {
+        init_err = true;
+        return error.InitFailed;
+    }
+
+    @atomicStore(bool, &initialized, true, .release);
 }
 
 pub fn cleanup() void {
+    init_mutex.lock();
+    defer init_mutex.unlock();
+
     if (ctx) |c| {
         _ = nc.NCDestroyContext(c);
         ctx = null;
     }
     initialized = false;
+    init_err = false;
 }
 
 pub fn verifySignature(pubkey: *const [32]u8, message: *const [32]u8, sig: *const [64]u8) !void {
@@ -59,6 +76,7 @@ pub fn sign(secret_key: *const [32]u8, message: *const [32]u8, sig_out: *[64]u8)
 
     var random: [32]u8 = undefined;
     std.crypto.random.bytes(&random);
+    defer std.crypto.secureZero(u8, &random);
 
     const result = nc.NCSignDigest(ctx, sk, &random, message, sig_out);
 

--- a/src/nip04.zig
+++ b/src/nip04.zig
@@ -70,7 +70,7 @@ pub fn encrypt(
     if (nc.NCGetSharedSecret(ctx, sk, pk, &shared_secret) != NC_SUCCESS) {
         return Nip04Error.EncryptionFailed;
     }
-    defer @memset(&shared_secret, 0);
+    defer std.crypto.secureZero(u8, &shared_secret);
 
     const padded_len = ((plaintext.len / BLOCK_SIZE) + 1) * BLOCK_SIZE;
     const padded = try allocator.alloc(u8, padded_len);
@@ -118,7 +118,7 @@ pub fn decrypt(
     if (nc.NCGetSharedSecret(ctx, sk, pk, &shared_secret) != NC_SUCCESS) {
         return Nip04Error.DecryptionFailed;
     }
-    defer @memset(&shared_secret, 0);
+    defer std.crypto.secureZero(u8, &shared_secret);
 
     const iv_sep = std.mem.indexOf(u8, payload, "?iv=") orelse return Nip04Error.InvalidPayload;
     const ct_b64 = payload[0..iv_sep];
@@ -148,9 +148,11 @@ pub fn decrypt(
     if (pad_byte == 0 or pad_byte > BLOCK_SIZE) return Nip04Error.InvalidPayload;
 
     const unpadded_len = ct_len - pad_byte;
+    var pad_valid: u8 = 0;
     for (plaintext[unpadded_len..ct_len]) |b| {
-        if (b != pad_byte) return Nip04Error.InvalidPayload;
+        pad_valid |= b ^ pad_byte;
     }
+    if (pad_valid != 0) return Nip04Error.InvalidPayload;
 
     const output = try allocator.realloc(plaintext, unpadded_len);
     return output;

--- a/src/nip04.zig
+++ b/src/nip04.zig
@@ -145,10 +145,11 @@ pub fn decrypt(
     aesCbcDecrypt(&shared_secret, &iv, ciphertext, plaintext);
 
     const pad_byte = plaintext[ct_len - 1];
-    if (pad_byte == 0 or pad_byte > BLOCK_SIZE) return Nip04Error.InvalidPayload;
+    const unpadded_len = ct_len -| pad_byte;
 
-    const unpadded_len = ct_len - pad_byte;
     var pad_valid: u8 = 0;
+    pad_valid |= @intFromBool(pad_byte == 0);
+    pad_valid |= @intFromBool(pad_byte > BLOCK_SIZE);
     for (plaintext[unpadded_len..ct_len]) |b| {
         pad_valid |= b ^ pad_byte;
     }

--- a/src/nip06.zig
+++ b/src/nip06.zig
@@ -93,7 +93,7 @@ fn masterKeyFromSeed(seed: []const u8, secret_key: *[32]u8, chain_code: *[32]u8)
 fn deriveHardenedChild(parent_key: *const [32]u8, parent_chain: *const [32]u8, index: u32, child_key: *[32]u8, child_chain: *[32]u8) !void {
     const hardened_index = index | 0x80000000;
     var data: [37]u8 = undefined;
-    defer @memset(&data, 0);
+    defer std.crypto.secureZero(u8, &data);
     data[0] = 0;
     @memcpy(data[1..33], parent_key);
     std.mem.writeInt(u32, data[33..37], hardened_index, .big);
@@ -101,7 +101,7 @@ fn deriveHardenedChild(parent_key: *const [32]u8, parent_chain: *const [32]u8, i
     var hmac = HmacSha512.init(parent_chain);
     hmac.update(&data);
     var result: [64]u8 = undefined;
-    defer @memset(&result, 0);
+    defer std.crypto.secureZero(u8, &result);
     hmac.final(&result);
 
     const il = result[0..32];
@@ -121,7 +121,7 @@ fn deriveNormalChild(parent_key: *const [32]u8, parent_chain: *const [32]u8, ind
     var hmac = HmacSha512.init(parent_chain);
     hmac.update(&data);
     var result: [64]u8 = undefined;
-    defer @memset(&result, 0);
+    defer std.crypto.secureZero(u8, &result);
     hmac.final(&result);
 
     const il = result[0..32];
@@ -205,19 +205,19 @@ fn isZero(key: *const [32]u8) bool {
 
 pub fn keypairFromMnemonic(mnemonic: []const u8, passphrase: []const u8, account: u32) !Keypair {
     var seed: [64]u8 = undefined;
-    defer @memset(&seed, 0);
+    defer std.crypto.secureZero(u8, &seed);
     try mnemonicToSeed(mnemonic, passphrase, &seed);
 
     var key: [32]u8 = undefined;
     var chain: [32]u8 = undefined;
-    defer @memset(&key, 0);
-    defer @memset(&chain, 0);
+    defer std.crypto.secureZero(u8, &key);
+    defer std.crypto.secureZero(u8, &chain);
     masterKeyFromSeed(&seed, &key, &chain);
 
     var child_key: [32]u8 = undefined;
     var child_chain: [32]u8 = undefined;
-    defer @memset(&child_key, 0);
-    defer @memset(&child_chain, 0);
+    defer std.crypto.secureZero(u8, &child_key);
+    defer std.crypto.secureZero(u8, &child_chain);
 
     try deriveHardenedChild(&key, &chain, 44, &child_key, &child_chain);
     key = child_key;

--- a/src/nip06.zig
+++ b/src/nip06.zig
@@ -60,7 +60,9 @@ pub fn mnemonicToSeed(mnemonic: []const u8, passphrase: []const u8, seed_out: *[
 
 fn pbkdf2HmacSha512(password: []const u8, salt: []const u8, iterations: u32, out: *[64]u8) void {
     var u: [64]u8 = undefined;
+    defer std.crypto.secureZero(u8, &u);
     var t: [64]u8 = undefined;
+    defer std.crypto.secureZero(u8, &t);
 
     var hmac = HmacSha512.init(password);
     hmac.update(salt);
@@ -85,6 +87,7 @@ fn masterKeyFromSeed(seed: []const u8, secret_key: *[32]u8, chain_code: *[32]u8)
     var hmac = HmacSha512.init("Bitcoin seed");
     hmac.update(seed);
     var result: [64]u8 = undefined;
+    defer std.crypto.secureZero(u8, &result);
     hmac.final(&result);
     secret_key.* = result[0..32].*;
     chain_code.* = result[32..64].*;
@@ -115,6 +118,7 @@ fn deriveNormalChild(parent_key: *const [32]u8, parent_chain: *const [32]u8, ind
     try getCompressedPubkey(parent_key, &compressed_pubkey);
 
     var data: [37]u8 = undefined;
+    defer std.crypto.secureZero(u8, &data);
     @memcpy(data[0..33], &compressed_pubkey);
     std.mem.writeInt(u32, data[33..37], index, .big);
 
@@ -173,11 +177,14 @@ fn addNoMod(a: *const [32]u8, b: *const [32]u8, result: *[32]u8) u16 {
 }
 
 fn compare(a: *const [32]u8, b: *const [32]u8) i32 {
+    var gt: u8 = 0;
+    var lt: u8 = 0;
     for (0..32) |i| {
-        if (a[i] < b[i]) return -1;
-        if (a[i] > b[i]) return 1;
+        const mask = ~(gt | lt);
+        gt |= @as(u8, @intFromBool(a[i] > b[i])) & mask;
+        lt |= @as(u8, @intFromBool(a[i] < b[i])) & mask;
     }
-    return 0;
+    return @as(i32, gt) - @as(i32, lt);
 }
 
 fn subtract(a: *const [32]u8, b: *const [32]u8, result: *[32]u8) void {
@@ -197,10 +204,11 @@ fn subtract(a: *const [32]u8, b: *const [32]u8, result: *[32]u8) void {
 }
 
 fn isZero(key: *const [32]u8) bool {
+    var acc: u8 = 0;
     for (key) |b| {
-        if (b != 0) return false;
+        acc |= b;
     }
-    return true;
+    return acc == 0;
 }
 
 pub fn keypairFromMnemonic(mnemonic: []const u8, passphrase: []const u8, account: u32) !Keypair {

--- a/src/nip59.zig
+++ b/src/nip59.zig
@@ -261,7 +261,7 @@ pub fn createSeal(
 
 pub const WrapResult = struct {
     json: []u8,
-    ephemeral_keypair: Keypair,
+    ephemeral_pubkey: [32]u8,
 };
 
 pub fn createGiftWrap(
@@ -270,7 +270,8 @@ pub fn createGiftWrap(
     out_buf: []u8,
     allocator: std.mem.Allocator,
 ) !WrapResult {
-    const ephemeral_keypair = Keypair.generate();
+    var ephemeral_keypair = Keypair.generate();
+    defer ephemeral_keypair.deinit();
 
     const encrypted_content = try crypto.nip44Encrypt(
         &ephemeral_keypair.secret_key,
@@ -301,7 +302,7 @@ pub fn createGiftWrap(
 
     return .{
         .json = json,
-        .ephemeral_keypair = ephemeral_keypair,
+        .ephemeral_pubkey = ephemeral_keypair.public_key,
     };
 }
 
@@ -336,46 +337,48 @@ pub fn unwrap(
     recipient_keypair: *const Keypair,
     allocator: std.mem.Allocator,
 ) !UnwrappedGiftWrap {
-    const wrap_kind = parseKind(gift_wrap_json) orelse return Error.InvalidEvent;
-    if (wrap_kind != Kind.gift_wrap) return Error.InvalidKind;
+    const Event = @import("event.zig").Event;
+
+    var wrap_event = Event.parseWithAllocator(gift_wrap_json, allocator) catch return Error.InvalidEvent;
+    defer wrap_event.deinit();
+
+    if (wrap_event.kind_val != Kind.gift_wrap) return Error.InvalidKind;
+
+    wrap_event.validate() catch return Error.InvalidEvent;
 
     const wrap_content = utils.extractJsonString(gift_wrap_json, "content") orelse return Error.MissingField;
-    const wrap_pubkey_hex = utils.extractJsonString(gift_wrap_json, "pubkey") orelse return Error.MissingField;
-
-    var wrap_pubkey: [32]u8 = undefined;
-    hex.decode(wrap_pubkey_hex, &wrap_pubkey) catch return Error.InvalidPayload;
 
     const seal_json = crypto.nip44Decrypt(
         &recipient_keypair.secret_key,
-        &wrap_pubkey,
+        &wrap_event.pubkey_bytes,
         wrap_content,
         allocator,
     ) catch return Error.DecryptionFailed;
     errdefer allocator.free(seal_json);
 
-    const seal_kind = parseKind(seal_json) orelse {
+    var seal_event = Event.parseWithAllocator(seal_json, allocator) catch {
         allocator.free(seal_json);
         return Error.InvalidEvent;
     };
-    if (seal_kind != Kind.seal) {
+    defer seal_event.deinit();
+
+    if (seal_event.kind_val != Kind.seal) {
         allocator.free(seal_json);
         return Error.InvalidKind;
     }
+
+    seal_event.validate() catch {
+        allocator.free(seal_json);
+        return Error.InvalidEvent;
+    };
 
     const seal_content = utils.extractJsonString(seal_json, "content") orelse {
         allocator.free(seal_json);
         return Error.MissingField;
     };
-    const seal_pubkey_hex = utils.extractJsonString(seal_json, "pubkey") orelse {
-        allocator.free(seal_json);
-        return Error.MissingField;
-    };
 
     var seal_pubkey: [32]u8 = undefined;
-    hex.decode(seal_pubkey_hex, &seal_pubkey) catch {
-        allocator.free(seal_json);
-        return Error.InvalidPayload;
-    };
+    @memcpy(&seal_pubkey, &seal_event.pubkey_bytes);
 
     const rumor_json = crypto.nip44Decrypt(
         &recipient_keypair.secret_key,

--- a/src/nip59.zig
+++ b/src/nip59.zig
@@ -356,39 +356,23 @@ pub fn unwrap(
     ) catch return Error.DecryptionFailed;
     errdefer allocator.free(seal_json);
 
-    var seal_event = Event.parseWithAllocator(seal_json, allocator) catch {
-        allocator.free(seal_json);
-        return Error.InvalidEvent;
-    };
+    var seal_event = Event.parseWithAllocator(seal_json, allocator) catch return Error.InvalidEvent;
     defer seal_event.deinit();
 
-    if (seal_event.kind_val != Kind.seal) {
-        allocator.free(seal_json);
-        return Error.InvalidKind;
-    }
+    if (seal_event.kind_val != Kind.seal) return Error.InvalidKind;
 
-    seal_event.validate() catch {
-        allocator.free(seal_json);
-        return Error.InvalidEvent;
-    };
+    seal_event.validate() catch return Error.InvalidEvent;
 
-    const seal_content = utils.extractJsonString(seal_json, "content") orelse {
-        allocator.free(seal_json);
-        return Error.MissingField;
-    };
+    const seal_content = utils.extractJsonString(seal_json, "content") orelse return Error.MissingField;
 
-    var seal_pubkey: [32]u8 = undefined;
-    @memcpy(&seal_pubkey, &seal_event.pubkey_bytes);
+    const seal_pubkey = seal_event.pubkey_bytes;
 
     const rumor_json = crypto.nip44Decrypt(
         &recipient_keypair.secret_key,
         &seal_pubkey,
         seal_content,
         allocator,
-    ) catch {
-        allocator.free(seal_json);
-        return Error.DecryptionFailed;
-    };
+    ) catch return Error.DecryptionFailed;
 
     return UnwrappedGiftWrap{
         .seal_json = seal_json,

--- a/src/ws/ssl.zig
+++ b/src/ws/ssl.zig
@@ -31,9 +31,11 @@ pub const SslStream = struct {
         const ctx = c.SSL_CTX_new(method) orelse return error.SslContextFailed;
         errdefer c.SSL_CTX_free(ctx);
 
-        if (c.SSL_CTX_set_min_proto_version(ctx, c.TLS1_2_VERSION) != 1) {
+        if (c.SSL_CTX_set_min_proto_version(ctx, c.TLS1_3_VERSION) != 1) {
             return error.SslContextFailed;
         }
+
+        _ = c.SSL_CTX_set_options(ctx, c.SSL_OP_NO_TICKET);
 
         if (c.SSL_CTX_set_default_verify_paths(ctx) != 1) {
             return error.SslContextFailed;

--- a/src/ws/ssl.zig
+++ b/src/ws/ssl.zig
@@ -31,6 +31,16 @@ pub const SslStream = struct {
         const ctx = c.SSL_CTX_new(method) orelse return error.SslContextFailed;
         errdefer c.SSL_CTX_free(ctx);
 
+        if (c.SSL_CTX_set_min_proto_version(ctx, c.TLS1_2_VERSION) != 1) {
+            return error.SslContextFailed;
+        }
+
+        if (c.SSL_CTX_set_default_verify_paths(ctx) != 1) {
+            return error.SslContextFailed;
+        }
+
+        c.SSL_CTX_set_verify(ctx, c.SSL_VERIFY_PEER, null);
+
         const alpn = "\x08http/1.1";
         if (c.SSL_CTX_set_alpn_protos(ctx, alpn, alpn.len) != 0) {
             return error.SslContextFailed;
@@ -46,6 +56,10 @@ pub const SslStream = struct {
         @memcpy(host_buf[0..host.len], host);
         host_buf[host.len] = 0;
         if (c.SSL_set_tlsext_host_name(ssl, &host_buf) != 1) {
+            return error.SslContextFailed;
+        }
+
+        if (c.SSL_set1_host(ssl, &host_buf) != 1) {
             return error.SslContextFailed;
         }
 


### PR DESCRIPTION
- Enable TLS certificate and hostname verification with minimum TLS 1.2
- Add mutex + atomic guards to crypto init for thread safety
- Use secureZero for all sensitive key material (entropy, nonces, shared secrets, seeds)
- Add Keypair.deinit() for secure secret key erasure
- Verify signatures on NIP-59 gift wrap and seal events during unwrap
- Stop leaking ephemeral secret key in WrapResult
- Add bounded mineWithLimit() for proof-of-work
- Use constant-time padding validation in NIP-04 decrypt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened encrypted payload validation to detect invalid padding
  * Enhanced SSL/TLS security with mandatory host verification and protocol enforcement
  * Improved sensitive data cleanup across cryptographic operations

* **Refactor**
  * Updated mining workflow to support optional iteration limits
  * Enhanced resource cleanup patterns for better memory management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->