### PR TITLE
build: add -Dlld option to work around self-hosted linker SFrame bug

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -50,6 +50,15 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+
+    // Recent glibc/binutils emit `.sframe` sections into the C runtime objects
+    // (crt1.o, libc_nonshared.a) that Zig's self-hosted ELF linker cannot yet
+    // relocate (R_X86_64_PC64), breaking `zig build test` on bleeding-edge
+    // Linux distros. Routing through LLVM + LLD handles SFrame. See issue #114.
+    if (b.option(bool, "lld", "Link with LLVM/LLD instead of Zig's self-hosted linker") orelse false) {
+        tests.use_llvm = true;
+        tests.use_lld = true;
+    }
     tests.linkLibrary(noscrypt.artifact("noscrypt"));
     tests.linkLibrary(sz_lib);
     tests.root_module.addIncludePath(noscrypt.path("include"));


### PR DESCRIPTION
Fixes #114.

## Problem

On bleeding-edge Linux toolchains (e.g. CachyOS, gcc 15.2 / recent binutils), `zig build test` fails with:

```
error: fatal linker error: unhandled relocation type R_X86_64_PC64 at offset 0x1c
    note: in .../crt1.o:.sframe
```

This is not a libnostr-z bug. Recent glibc/binutils emit `.sframe` stack-trace sections (with `R_X86_64_PC64` relocations) into the C runtime objects (`crt1.o`, `libc_nonshared.a`). Zig 0.15's default native x86_64 Debug pipeline links with its self-hosted ELF linker, which cannot yet relocate `.sframe`. Older toolchains (gcc 13 / Ubuntu) don't emit `.sframe`, so it only reproduces on the newest distros.

## Fix

Add an opt-in `-Dlld` build option that links the test binary with LLD, which handles SFrame. In Zig 0.15 `-flld` requires `-fllvm` (self-hosted backends can't link with LLD), so the option enables both.

Affected users run:

```
zig build test -Dlld
```

The option is off by default, so the common (faster) self-hosted path is unchanged and we don't force an LLVM-enabled Zig on users who don't need it.

## Verification

On Zig 0.15.2, both configurations pass 644/644 tests:

- `zig build test` (self-hosted)
- `zig build test -Dlld` (LLVM + LLD)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system with an optional configuration flag to improve test compilation compatibility on certain Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->