### PR TITLE
Migrate to Zig 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build
         run: zig build

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ Thumbs.db
 
 # Debug
 *.pdb
+zig-pkg/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # libnostr-z
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Zig](https://img.shields.io/badge/Zig-0.15-orange.svg)](https://ziglang.org/)
+[![Zig](https://img.shields.io/badge/Zig-0.16-orange.svg)](https://ziglang.org/)
 
 A Zig library for the Nostr protocol.
+
+> Requires Zig 0.16. For Zig 0.15, use the `v0.2.0` release.
 
 ## NIP Support
 

--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/root.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
 
@@ -59,12 +60,11 @@ pub fn build(b: *std.Build) void {
         tests.use_llvm = true;
         tests.use_lld = true;
     }
-    tests.linkLibrary(noscrypt.artifact("noscrypt"));
-    tests.linkLibrary(sz_lib);
+    tests.root_module.linkLibrary(noscrypt.artifact("noscrypt"));
+    tests.root_module.linkLibrary(sz_lib);
     tests.root_module.addIncludePath(noscrypt.path("include"));
     tests.root_module.linkSystemLibrary("ssl", .{});
     tests.root_module.linkSystemLibrary("crypto", .{});
-    tests.linkLibC();
 
     const run_tests = b.addRunArtifact(tests);
     b.step("test", "Run tests").dependOn(&run_tests.step);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,15 +1,15 @@
 .{
     .name = .nostr,
-    .version = "0.2.0",
+    .version = "0.3.0",
     .fingerprint = 0x208aa38f708e8e25,
     .dependencies = .{
         .noscrypt = .{
-            .url = "https://github.com/privkeyio/noscrypt/archive/6f9ce44.tar.gz",
-            .hash = "noscrypt-0.1.9-q33-Y_9w5wDS6fAVp_8IQAg8aiZkYMe07TT4i1sBks7L",
+            .url = "https://github.com/privkeyio/noscrypt/archive/01f2ed5801198da139fd9856dcc475a80121acf5.tar.gz",
+            .hash = "noscrypt-0.1.14-q33-Y3suyADLggvQIxeDkW7bCwZA4VuR2zAnm9M2Sbva",
         },
         .stringzilla = .{
             .url = "https://github.com/ashvardanian/StringZilla/archive/refs/tags/v4.5.1.tar.gz",
-            .hash = "1220683347bf6825659abe1b5d8de11a735259258d865b8cb02b393e7f5c18219e50",
+            .hash = "N-V-__8AAAZ8QgBoM0e_aCVlmr4bXY3hGnNSWSWNhluMsCs5",
         },
     },
     .paths = .{

--- a/src/badges.zig
+++ b/src/badges.zig
@@ -42,7 +42,7 @@ pub const BadgeDefinition = struct {
             .description = null,
             .image_url = null,
             .image_dimensions = null,
-            .thumbnails = .{},
+            .thumbnails = .empty,
             .allocator = allocator,
         };
     }
@@ -113,7 +113,7 @@ pub const BadgeAward = struct {
     pub fn init(allocator: std.mem.Allocator) BadgeAward {
         return .{
             .badge_address = "",
-            .awarded_pubkeys = .{},
+            .awarded_pubkeys = .empty,
             .allocator = allocator,
         };
     }
@@ -177,7 +177,7 @@ pub const ProfileBadges = struct {
 
     pub fn init(allocator: std.mem.Allocator) ProfileBadges {
         return .{
-            .badges = .{},
+            .badges = .empty,
             .allocator = allocator,
         };
     }

--- a/src/bech32.zig
+++ b/src/bech32.zig
@@ -307,7 +307,7 @@ pub fn decodeNostr(allocator: std.mem.Allocator, input: []const u8) !Decoded {
 
 fn decodeTlvProfile(allocator: std.mem.Allocator, data: []const u8) !Decoded {
     var pubkey: ?[32]u8 = null;
-    var relays: std.ArrayListUnmanaged([]const u8) = .{};
+    var relays: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (relays.items) |r| allocator.free(r);
         relays.deinit(allocator);
@@ -345,7 +345,7 @@ fn decodeTlvEvent(allocator: std.mem.Allocator, data: []const u8) !Decoded {
     var id: ?[32]u8 = null;
     var author: ?[32]u8 = null;
     var kind: ?u32 = null;
-    var relays: std.ArrayListUnmanaged([]const u8) = .{};
+    var relays: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (relays.items) |r| allocator.free(r);
         relays.deinit(allocator);
@@ -389,7 +389,7 @@ fn decodeTlvAddr(allocator: std.mem.Allocator, data: []const u8) !Decoded {
     var identifier: ?[]const u8 = null;
     var pubkey: ?[32]u8 = null;
     var kind: ?u32 = null;
-    var relays: std.ArrayListUnmanaged([]const u8) = .{};
+    var relays: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         if (identifier) |id| allocator.free(id);
         for (relays.items) |r| allocator.free(r);
@@ -472,7 +472,7 @@ fn decodeTlvOffer(allocator: std.mem.Allocator, data: []const u8) !Decoded {
                 offer_id = new_offer_id;
             },
             3 => if (l == 1) {
-                pricing_type = std.meta.intToEnum(Decoded.PricingType, v[0]) catch null;
+                pricing_type = std.enums.fromInt(Decoded.PricingType, v[0]) orelse null;
             },
             4 => if (l == 8) {
                 price = std.mem.readInt(u64, v[0..8], .big);

--- a/src/builder.zig
+++ b/src/builder.zig
@@ -10,7 +10,7 @@ pub const Keypair = struct {
 
     pub fn generate() Keypair {
         var secret_key: [32]u8 = undefined;
-        std.crypto.random.bytes(&secret_key);
+        @import("io.zig").randomBytes(&secret_key);
         defer std.crypto.secureZero(u8, &secret_key);
 
         var public_key: [32]u8 = undefined;
@@ -63,12 +63,12 @@ pub const EventBuilder = struct {
         @memcpy(&self.pubkey_bytes, &keypair.public_key);
 
         if (self.created_at_val == 0) {
-            self.created_at_val = std.time.timestamp();
+            self.created_at_val = @import("io.zig").timestamp();
         }
 
         var commitment_buf: [8192]u8 = undefined;
-        var fbs = std.io.fixedBufferStream(&commitment_buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(&commitment_buf);
+        const writer = &fbs;
 
         try writer.writeAll("[0,\"");
 
@@ -98,7 +98,7 @@ pub const EventBuilder = struct {
         try utils.writeJsonEscaped(writer, self.content_slice);
         try writer.writeAll("\"]");
 
-        const commitment = fbs.getWritten();
+        const commitment = fbs.buffered();
         std.crypto.hash.sha2.Sha256.hash(commitment, &self.id_bytes, .{});
 
         crypto.sign(&keypair.secret_key, &self.id_bytes, &self.sig_bytes) catch {
@@ -114,7 +114,7 @@ pub const EventBuilder = struct {
         @memcpy(&self.pubkey_bytes, &keypair.public_key);
 
         if (self.created_at_val == 0) {
-            self.created_at_val = std.time.timestamp();
+            self.created_at_val = @import("io.zig").timestamp();
         }
 
         var nonce: u64 = 0;
@@ -123,8 +123,8 @@ pub const EventBuilder = struct {
         const target_str = std.fmt.bufPrint(&target_str_buf, "{d}", .{target_difficulty}) catch unreachable;
 
         var commitment_prefix_buf: [8192]u8 = undefined;
-        var prefix_fbs = std.io.fixedBufferStream(&commitment_prefix_buf);
-        const prefix_writer = prefix_fbs.writer();
+        var prefix_fbs = std.Io.Writer.fixed(&commitment_prefix_buf);
+        const prefix_writer = &prefix_fbs;
 
         try prefix_writer.writeAll("[0,\"");
         var mine_pk_hex: [64]u8 = undefined;
@@ -149,7 +149,7 @@ pub const EventBuilder = struct {
         }
 
         const has_existing_tags = self.tags_data.len > 0;
-        const prefix = prefix_fbs.getWritten();
+        const prefix = prefix_fbs.buffered();
 
         while (true) : (nonce += 1) {
             if (max_iterations) |limit| {
@@ -183,8 +183,8 @@ pub const EventBuilder = struct {
     }
 
     pub fn serialize(self: *const EventBuilder, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"id\":\"");
         var ser_id_hex: [64]u8 = undefined;
@@ -229,7 +229,7 @@ pub const EventBuilder = struct {
         try writer.writeAll(&ser_sig_hex);
         try writer.writeAll("\"}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/classified_listing.zig
+++ b/src/classified_listing.zig
@@ -55,8 +55,8 @@ pub const ClassifiedListing = struct {
 
     pub fn init(allocator: std.mem.Allocator) ClassifiedListing {
         return .{
-            .hashtags = .{},
-            .images = .{},
+            .hashtags = .empty,
+            .images = .empty,
             .allocator = allocator,
         };
     }

--- a/src/clink.zig
+++ b/src/clink.zig
@@ -45,8 +45,8 @@ pub const OffersResponse = struct {
     }
 
     pub fn format(self: OffersResponse, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         if (self.bolt11) |b| {
             try writer.writeAll("{\"bolt11\":\"");
@@ -59,7 +59,7 @@ pub const OffersResponse = struct {
         } else {
             try writer.writeAll("{\"res\":\"ok\"}");
         }
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -133,8 +133,8 @@ pub const DebitResponse = struct {
     }
 
     pub fn format(self: DebitResponse, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         if (self.preimage) |p| {
             try writer.writeAll("{\"res\":\"ok\",\"preimage\":\"");
@@ -143,7 +143,7 @@ pub const DebitResponse = struct {
         } else {
             try writer.writeAll("{\"res\":\"ok\"}");
         }
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -205,8 +205,8 @@ pub const ManageResponse = struct {
     }
 
     pub fn format(self: ManageResponse, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"res\":\"ok\",\"resource\":\"");
         try utils.writeJsonEscaped(writer, self.resource);
@@ -218,7 +218,7 @@ pub const ManageResponse = struct {
         }
 
         try writer.writeByte('}');
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -308,8 +308,8 @@ pub const OffersError = struct {
     latest: ?[]const u8 = null,
 
     pub fn format(self: OffersError, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"error\":\"");
         try utils.writeJsonEscaped(writer, self.error_msg);
@@ -326,7 +326,7 @@ pub const OffersError = struct {
         }
 
         try writer.writeByte('}');
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -339,8 +339,8 @@ pub const GfyError = struct {
     field: ?[]const u8 = null,
 
     pub fn format(self: GfyError, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.print("{{\"res\":\"GFY\",\"code\":{d},\"error\":\"", .{self.code.toInt()});
         try utils.writeJsonEscaped(writer, self.error_msg);
@@ -365,7 +365,7 @@ pub const GfyError = struct {
         }
 
         try writer.writeByte('}');
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/crypto.zig
+++ b/src/crypto.zig
@@ -7,7 +7,7 @@ const nc = @cImport({
 const NC_SUCCESS: i64 = 0;
 
 var ctx: ?*nc.NCContext = null;
-var init_mutex: std.Thread.Mutex = .{};
+var init_mutex: std.Io.Mutex = .init;
 var initialized = false;
 var init_err = false;
 
@@ -21,8 +21,8 @@ pub const CryptoError = error{
 pub fn init() !void {
     if (@atomicLoad(bool, &initialized, .acquire)) return;
 
-    init_mutex.lock();
-    defer init_mutex.unlock();
+    init_mutex.lockUncancelable(@import("io.zig").io());
+    defer init_mutex.unlock(@import("io.zig").io());
 
     if (initialized) return;
     if (init_err) return error.InitFailed;
@@ -34,7 +34,7 @@ pub fn init() !void {
     }
 
     var entropy: [32]u8 = undefined;
-    std.crypto.random.bytes(&entropy);
+    @import("io.zig").randomBytes(&entropy);
     defer std.crypto.secureZero(u8, &entropy);
 
     const result = nc.NCInitContext(ctx, &entropy);
@@ -47,8 +47,8 @@ pub fn init() !void {
 }
 
 pub fn cleanup() void {
-    init_mutex.lock();
-    defer init_mutex.unlock();
+    init_mutex.lockUncancelable(@import("io.zig").io());
+    defer init_mutex.unlock(@import("io.zig").io());
 
     if (ctx) |c| {
         _ = nc.NCDestroyContext(c);
@@ -75,7 +75,7 @@ pub fn sign(secret_key: *const [32]u8, message: *const [32]u8, sig_out: *[64]u8)
     const sk = nc.NCByteCastToSecretKey(secret_key);
 
     var random: [32]u8 = undefined;
-    std.crypto.random.bytes(&random);
+    @import("io.zig").randomBytes(&random);
     defer std.crypto.secureZero(u8, &random);
 
     const result = nc.NCSignDigest(ctx, sk, &random, message, sig_out);
@@ -179,7 +179,7 @@ pub fn nip44Encrypt(
     defer allocator.free(ciphertext);
 
     var nonce: [32]u8 = undefined;
-    std.crypto.random.bytes(&nonce);
+    @import("io.zig").randomBytes(&nonce);
 
     var hmac_key: [32]u8 = undefined;
     defer std.crypto.secureZero(u8, &hmac_key);

--- a/src/custom_emoji.zig
+++ b/src/custom_emoji.zig
@@ -15,7 +15,7 @@ pub const EmojiList = struct {
 
     pub fn init(allocator: std.mem.Allocator) EmojiList {
         return .{
-            .emojis = .{},
+            .emojis = .empty,
             .allocator = allocator,
         };
     }

--- a/src/dlc_oracle.zig
+++ b/src/dlc_oracle.zig
@@ -15,7 +15,7 @@ pub const OracleAnnouncement = struct {
     asset_pair: ?AssetPair = null,
 
     pub fn parse(allocator: std.mem.Allocator, content: []const u8, tags_json: []const u8) !OracleAnnouncement {
-        var relays: std.ArrayListUnmanaged([]const u8) = .{};
+        var relays: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (relays.items) |relay| allocator.free(relay);
             relays.deinit(allocator);
@@ -25,7 +25,7 @@ pub const OracleAnnouncement = struct {
         errdefer if (title) |t| allocator.free(t);
         var description: ?[]const u8 = null;
         errdefer if (description) |d| allocator.free(d);
-        var n_tags: std.ArrayListUnmanaged([]const u8) = .{};
+        var n_tags: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
             for (n_tags.items) |n| allocator.free(n);
             n_tags.deinit(allocator);
@@ -95,8 +95,8 @@ pub const OracleAnnouncement = struct {
     }
 
     pub fn serialize(self: *const OracleAnnouncement, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"kind\":88,\"content\":\"");
         try utils.writeJsonEscaped(writer, self.announcement_data);
@@ -136,7 +136,7 @@ pub const OracleAnnouncement = struct {
         }
 
         try writer.writeAll("]}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -149,7 +149,7 @@ pub const OracleAttestation = struct {
         var announcement_id: ?[]const u8 = null;
         errdefer if (announcement_id) |id| allocator.free(id);
         var asset_pair: ?AssetPair = null;
-        var n_tags: std.ArrayListUnmanaged([]const u8) = .{};
+        var n_tags: std.ArrayListUnmanaged([]const u8) = .empty;
         defer {
             for (n_tags.items) |n| allocator.free(n);
             n_tags.deinit(allocator);
@@ -201,8 +201,8 @@ pub const OracleAttestation = struct {
     }
 
     pub fn serialize(self: *const OracleAttestation, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"kind\":89,\"content\":\"");
         try utils.writeJsonEscaped(writer, self.attestation_data);
@@ -219,7 +219,7 @@ pub const OracleAttestation = struct {
         }
 
         try writer.writeAll("]}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -237,7 +237,7 @@ pub const TrustedOraclesList = struct {
     oracles: []TrustedOracle,
 
     pub fn parse(allocator: std.mem.Allocator, tags_json: []const u8) !TrustedOraclesList {
-        var oracles: std.ArrayListUnmanaged(TrustedOracle) = .{};
+        var oracles: std.ArrayListUnmanaged(TrustedOracle) = .empty;
         errdefer {
             for (oracles.items) |oracle| {
                 allocator.free(oracle.pubkey);
@@ -276,8 +276,8 @@ pub const TrustedOraclesList = struct {
     }
 
     pub fn serialize(self: *const TrustedOraclesList, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"kind\":10088,\"tags\":[");
 
@@ -295,12 +295,12 @@ pub const TrustedOraclesList = struct {
         }
 
         try writer.writeAll("]}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
 fn extractAllTagValues(allocator: std.mem.Allocator, json: []const u8, start_pos: usize) ![][]const u8 {
-    var values: std.ArrayListUnmanaged([]const u8) = .{};
+    var values: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (values.items) |v| allocator.free(v);
         values.deinit(allocator);
@@ -429,7 +429,7 @@ fn extractSecondTagValue(json: []const u8, start_pos: usize) ?[]const u8 {
 }
 
 fn extractRelaysFromSTag(allocator: std.mem.Allocator, json: []const u8, start_pos: usize) ![][]const u8 {
-    var relays: std.ArrayListUnmanaged([]const u8) = .{};
+    var relays: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
         for (relays.items) |r| allocator.free(r);
         relays.deinit(allocator);

--- a/src/event.zig
+++ b/src/event.zig
@@ -90,7 +90,7 @@ pub const Event = struct {
             .kind_val = kind_num,
             .raw_json = json,
             .allocator = allocator,
-            .e_tags = .{},
+            .e_tags = .empty,
             .tags = TagIndex.init(allocator),
         };
 
@@ -139,7 +139,7 @@ pub const Event = struct {
     }
 
     pub fn validate(self: *const Event) Error!void {
-        const now = std.time.timestamp();
+        const now = @import("io.zig").timestamp();
         if (self.created_at_val > now + 900) return error.FutureEvent;
 
         const computed_id = self.computeId() catch return error.IdMismatch;
@@ -402,7 +402,7 @@ pub fn kindType(kind_num: i32) Kind.Type {
 
 pub fn isExpired(event: *const Event) bool {
     if (event.expiration_val) |exp| {
-        return std.time.timestamp() > exp;
+        return @import("io.zig").timestamp() > exp;
     }
     return false;
 }

--- a/src/external_identities.zig
+++ b/src/external_identities.zig
@@ -46,7 +46,7 @@ pub const IdentityList = struct {
 
     pub fn init(allocator: std.mem.Allocator) IdentityList {
         return .{
-            .identities = .{},
+            .identities = .empty,
             .allocator = allocator,
         };
     }
@@ -152,8 +152,8 @@ const IdentityTagIterator = struct {
 };
 
 pub fn getProofUrl(identity: ExternalIdentity, buf: []u8) ?[]u8 {
-    var stream = std.io.fixedBufferStream(buf);
-    const writer = stream.writer();
+    var stream = std.Io.Writer.fixed(buf);
+    const writer = &stream;
 
     switch (identity.platform) {
         .github => {
@@ -171,15 +171,15 @@ pub fn getProofUrl(identity: ExternalIdentity, buf: []u8) ?[]u8 {
         .unknown => return null,
     }
 
-    return buf[0..stream.pos];
+    return stream.buffered();
 }
 
 pub fn getExpectedProofText(platform: Platform, pubkey: *const [32]u8, buf: []u8) ?[]u8 {
     var npub_buf: [63]u8 = undefined;
     bech32.encodeNpub(pubkey, &npub_buf);
 
-    var stream = std.io.fixedBufferStream(buf);
-    const writer = stream.writer();
+    var stream = std.Io.Writer.fixed(buf);
+    const writer = &stream;
 
     switch (platform) {
         .github => {
@@ -194,7 +194,7 @@ pub fn getExpectedProofText(platform: Platform, pubkey: *const [32]u8, buf: []u8
         .unknown => return null,
     }
 
-    return buf[0..stream.pos];
+    return stream.buffered();
 }
 
 pub fn buildIdentityTags(

--- a/src/file_metadata.zig
+++ b/src/file_metadata.zig
@@ -77,7 +77,7 @@ pub const FileMetadata = struct {
         var image: ?ImageRef = null;
         var summary: ?[]const u8 = null;
         var alt: ?[]const u8 = null;
-        var fallbacks = std.ArrayListUnmanaged([]const u8){};
+        var fallbacks = std.ArrayListUnmanaged([]const u8).empty;
         var service: ?[]const u8 = null;
 
         errdefer {

--- a/src/filter.zig
+++ b/src/filter.zig
@@ -159,8 +159,8 @@ pub const Filter = struct {
     }
 
     pub fn serialize(self: *const Filter, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeByte('{');
         var first = true;
@@ -255,7 +255,7 @@ pub const Filter = struct {
 
         try writer.writeByte('}');
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn deinit(self: *Filter) void {

--- a/src/http_auth.zig
+++ b/src/http_auth.zig
@@ -86,7 +86,7 @@ pub const HttpAuth = struct {
         if (kind != Kind) return error.InvalidKind;
 
         const created_at = utils.extractIntField(json, "created_at", i64) orelse return error.EventExpired;
-        const now = std.time.timestamp();
+        const now = @import("io.zig").timestamp();
         const window = time_window orelse DefaultTimeWindow;
 
         if (created_at < now - window) return error.EventExpired;
@@ -127,7 +127,7 @@ pub const HttpAuth = struct {
         // Now validate NIP-98 specific fields
         if (event.kind() != Kind) return error.InvalidKind;
 
-        const now = std.time.timestamp();
+        const now = @import("io.zig").timestamp();
         const window = time_window orelse DefaultTimeWindow;
         const created_at = event.createdAt();
 
@@ -281,7 +281,7 @@ test "HttpAuth.validate kind check" {
 }
 
 test "HttpAuth.validate url mismatch" {
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"abc","pubkey":"def","sig":"ghi","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com/v1"],["method","GET"]]}}
@@ -291,7 +291,7 @@ test "HttpAuth.validate url mismatch" {
 }
 
 test "HttpAuth.validate method mismatch" {
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"abc","pubkey":"def","sig":"ghi","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com"],["method","GET"]]}}
@@ -301,7 +301,7 @@ test "HttpAuth.validate method mismatch" {
 }
 
 test "HttpAuth.validate success" {
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"abc","pubkey":"def","sig":"ghi","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com"],["method","GET"]]}}
@@ -311,7 +311,7 @@ test "HttpAuth.validate success" {
 }
 
 test "HttpAuth.validate with payload" {
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"abc","pubkey":"def","sig":"ghi","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com"],["method","POST"],["payload","abc123"]]}}
@@ -332,7 +332,7 @@ test "HttpAuth.validate expired event" {
 }
 
 test "HttpAuth.validate future event" {
-    const future_time = std.time.timestamp() + 3600;
+    const future_time = @import("io.zig").timestamp() + 3600;
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"abc","pubkey":"def","sig":"ghi","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com"],["method","GET"]]}}
@@ -373,7 +373,7 @@ test "HttpAuth.validateAndVerify rejects invalid signature" {
     defer event_mod.cleanup();
 
     // Manually crafted event with invalid signature
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var json_buf: [512]u8 = undefined;
     const json = std.fmt.bufPrint(&json_buf,
         \\{{"id":"0000000000000000000000000000000000000000000000000000000000000000","pubkey":"0000000000000000000000000000000000000000000000000000000000000000","sig":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","kind":27235,"created_at":{d},"content":"","tags":[["u","https://api.example.com"],["method","GET"]]}}

--- a/src/io.zig
+++ b/src/io.zig
@@ -1,0 +1,41 @@
+const std = @import("std");
+
+var threaded: std.Io.Threaded = undefined;
+var io_val: std.Io = undefined;
+var ready = std.atomic.Value(bool).init(false);
+var initializing = std.atomic.Value(bool).init(false);
+
+/// Lazily-initialized process-global blocking Io for time/random.
+pub fn io() std.Io {
+    if (ready.load(.acquire)) return io_val;
+    // Bootstrap lock: a plain spinlock, because std.Io.Mutex itself needs an
+    // Io to lock and this is what produces that Io.
+    while (initializing.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+        std.atomic.spinLoopHint();
+    }
+    defer initializing.store(false, .release);
+    if (!ready.load(.acquire)) {
+        threaded = std.Io.Threaded.init(std.heap.page_allocator, .{});
+        io_val = threaded.io();
+        ready.store(true, .release);
+    }
+    return io_val;
+}
+
+/// Unix time in seconds (wall clock). Replacement for std.time.timestamp().
+pub fn timestamp() i64 {
+    return std.Io.Timestamp.now(io(), .real).toSeconds();
+}
+
+/// Unix time in nanoseconds. Replacement for std.time.nanoTimestamp().
+pub fn nanoTimestamp() i128 {
+    return @intCast(std.Io.Timestamp.now(io(), .real).toNanoseconds());
+}
+
+/// Fill buffer with cryptographically-secure random bytes.
+/// Replacement for std.crypto.random.bytes(). Uses randomSecure so entropy is
+/// always sourced from the OS; panics if entropy is unavailable rather than
+/// silently falling back to a weak seed (matches the old fail-closed behavior).
+pub fn randomBytes(buf: []u8) void {
+    io().randomSecure(buf) catch @panic("randomSecure: entropy unavailable");
+}

--- a/src/joinstr.zig
+++ b/src/joinstr.zig
@@ -86,8 +86,8 @@ pub const Pool = struct {
     }
 
     pub fn serialize(self: *const Pool, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"type\":\"new_pool\",\"id\":\"");
         try utils.writeJsonEscaped(writer, self.id);
@@ -113,7 +113,7 @@ pub const Pool = struct {
         }
         try writer.writeAll("}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -129,14 +129,14 @@ pub const OutputMessage = struct {
     }
 
     pub fn serialize(self: *const OutputMessage, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"address\":\"");
         try utils.writeJsonEscaped(writer, self.address);
         try writer.writeAll("\",\"type\":\"output\"}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -152,14 +152,14 @@ pub const InputMessage = struct {
     }
 
     pub fn serialize(self: *const InputMessage, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"psbt\":\"");
         try utils.writeJsonEscaped(writer, self.psbt);
         try writer.writeAll("\",\"type\":\"input\"}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/message_queue.zig
+++ b/src/message_queue.zig
@@ -3,8 +3,7 @@ const std = @import("std");
 pub const MessageQueue = struct {
     allocator: std.mem.Allocator,
     messages: std.ArrayListUnmanaged(QueuedMessage),
-    mutex: std.Thread.Mutex,
-    condition: std.Thread.Condition,
+    mutex: std.Io.Mutex,
     max_size: usize,
 
     pub const QueuedMessage = struct {
@@ -20,16 +19,15 @@ pub const MessageQueue = struct {
     pub fn initWithCapacity(allocator: std.mem.Allocator, max_size: usize) MessageQueue {
         return .{
             .allocator = allocator,
-            .messages = .{},
-            .mutex = .{},
-            .condition = .{},
+            .messages = .empty,
+            .mutex = .init,
             .max_size = max_size,
         };
     }
 
     pub fn deinit(self: *MessageQueue) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.messages.items) |item| {
             self.allocator.free(item.data);
@@ -39,8 +37,8 @@ pub const MessageQueue = struct {
     }
 
     pub fn push(self: *MessageQueue, data: []const u8, relay_url: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.messages.items.len >= self.max_size) {
             const oldest = self.messages.orderedRemove(0);
@@ -57,14 +55,13 @@ pub const MessageQueue = struct {
         try self.messages.append(self.allocator, .{
             .data = duped_data,
             .relay_url = duped_url,
-            .received_at = std.time.timestamp(),
+            .received_at = @import("io.zig").timestamp(),
         });
-        self.condition.signal();
     }
 
     pub fn pop(self: *MessageQueue) ?QueuedMessage {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.messages.items.len == 0) {
             return null;
@@ -74,42 +71,43 @@ pub const MessageQueue = struct {
     }
 
     pub fn popWithTimeout(self: *MessageQueue, timeout_ns: u64) ?QueuedMessage {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
-        const start_time = std.time.nanoTimestamp();
+        const start_time = @import("io.zig").nanoTimestamp();
 
         while (self.messages.items.len == 0) {
-            const now = std.time.nanoTimestamp();
+            const now = @import("io.zig").nanoTimestamp();
             const elapsed: u64 = if (now > start_time) @intCast(now - start_time) else 0;
             if (elapsed >= timeout_ns) {
                 return null;
             }
 
             const remaining = timeout_ns - elapsed;
-            self.condition.timedWait(&self.mutex, remaining) catch {
-                return null;
-            };
+            const wait_ns = @min(remaining, 1_000_000);
+            self.mutex.unlock(@import("io.zig").io());
+            std.Io.sleep(@import("io.zig").io(), .{ .nanoseconds = @intCast(wait_ns) }, .awake) catch {};
+            self.mutex.lockUncancelable(@import("io.zig").io());
         }
 
         return self.messages.orderedRemove(0);
     }
 
     pub fn isEmpty(self: *MessageQueue) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.messages.items.len == 0;
     }
 
     pub fn size(self: *MessageQueue) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.messages.items.len;
     }
 
     pub fn sortByTimestamp(self: *MessageQueue) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         std.mem.sort(QueuedMessage, self.messages.items, {}, struct {
             pub fn lessThan(_: void, a: QueuedMessage, b: QueuedMessage) bool {
@@ -124,8 +122,8 @@ pub const MessageQueue = struct {
     }
 
     pub fn clear(self: *MessageQueue) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.messages.items) |item| {
             self.allocator.free(item.data);
@@ -186,9 +184,9 @@ test "sort by timestamp" {
     defer queue.deinit();
 
     try queue.push("msg1", "relay1");
-    std.Thread.sleep(1_000_000);
+    std.Io.sleep(@import("io.zig").io(), .{ .nanoseconds = 1_000_000 }, .awake) catch {};
     try queue.push("msg2", "relay2");
-    std.Thread.sleep(1_000_000);
+    std.Io.sleep(@import("io.zig").io(), .{ .nanoseconds = 1_000_000 }, .awake) catch {};
     try queue.push("msg3", "relay3");
 
     queue.sortByTimestamp();
@@ -269,12 +267,9 @@ test "thread safety - concurrent push and pop" {
                 var buf: [32]u8 = undefined;
                 const msg = std.fmt.bufPrint(&buf, "msg_{d}", .{i}) catch unreachable;
                 q.push(msg, "relay") catch {};
-                std.Thread.sleep(100_000);
+                std.Io.sleep(@import("io.zig").io(), .{ .nanoseconds = 100_000 }, .awake) catch {};
             }
             done.store(true, .release);
-            q.mutex.lock();
-            q.condition.broadcast();
-            q.mutex.unlock();
         }
     }.run, .{ &queue, &producer_done });
 

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -123,7 +123,7 @@ pub const ClientMsg = struct {
         const arr = parsed.value.array.items;
         if (arr.len < 3) return &[_]Filter{};
 
-        var filters: std.ArrayListUnmanaged(Filter) = .{};
+        var filters: std.ArrayListUnmanaged(Filter) = .empty;
         errdefer filters.deinit(allocator);
 
         for (arr[2..]) |filter_val| {
@@ -135,7 +135,7 @@ pub const ClientMsg = struct {
 
             if (filter_obj.get("ids")) |ids_val| {
                 if (ids_val == .array) {
-                    var ids_list: std.ArrayListUnmanaged([32]u8) = .{};
+                    var ids_list: std.ArrayListUnmanaged([32]u8) = .empty;
                     for (ids_val.array.items) |id_val| {
                         if (id_val == .string and id_val.string.len == 64) {
                             var id_bytes: [32]u8 = undefined;
@@ -154,7 +154,7 @@ pub const ClientMsg = struct {
 
             if (filter_obj.get("authors")) |authors_val| {
                 if (authors_val == .array) {
-                    var authors_list: std.ArrayListUnmanaged([32]u8) = .{};
+                    var authors_list: std.ArrayListUnmanaged([32]u8) = .empty;
                     for (authors_val.array.items) |author_val| {
                         if (author_val == .string and author_val.string.len == 64) {
                             var author_bytes: [32]u8 = undefined;
@@ -173,7 +173,7 @@ pub const ClientMsg = struct {
 
             if (filter_obj.get("kinds")) |kinds_val| {
                 if (kinds_val == .array) {
-                    var kinds_list: std.ArrayListUnmanaged(i32) = .{};
+                    var kinds_list: std.ArrayListUnmanaged(i32) = .empty;
                     for (kinds_val.array.items) |k| {
                         if (k == .integer) {
                             try kinds_list.append(allocator, @intCast(k.integer));
@@ -210,7 +210,7 @@ pub const ClientMsg = struct {
                 }
             }
 
-            var tag_entries: std.ArrayListUnmanaged(FilterTagEntry) = .{};
+            var tag_entries: std.ArrayListUnmanaged(FilterTagEntry) = .empty;
             errdefer {
                 for (tag_entries.items) |entry| {
                     for (entry.values) |val| {
@@ -232,7 +232,7 @@ pub const ClientMsg = struct {
                     if ((letter >= 'a' and letter <= 'z') or (letter >= 'A' and letter <= 'Z')) {
                         const tag_val = kv.value_ptr.*;
                         if (tag_val == .array) {
-                            var values_list: std.ArrayListUnmanaged(TagValue) = .{};
+                            var values_list: std.ArrayListUnmanaged(TagValue) = .empty;
                             errdefer values_list.deinit(allocator);
 
                             for (tag_val.array.items) |item| {
@@ -296,7 +296,7 @@ pub const ClientMsg = struct {
 
         if (filter_obj.get("ids")) |ids_val| {
             if (ids_val == .array) {
-                var ids_list: std.ArrayListUnmanaged([32]u8) = .{};
+                var ids_list: std.ArrayListUnmanaged([32]u8) = .empty;
                 for (ids_val.array.items) |id_val| {
                     if (id_val == .string and id_val.string.len == 64) {
                         var id_bytes: [32]u8 = undefined;
@@ -315,7 +315,7 @@ pub const ClientMsg = struct {
 
         if (filter_obj.get("authors")) |authors_val| {
             if (authors_val == .array) {
-                var authors_list: std.ArrayListUnmanaged([32]u8) = .{};
+                var authors_list: std.ArrayListUnmanaged([32]u8) = .empty;
                 for (authors_val.array.items) |author_val| {
                     if (author_val == .string and author_val.string.len == 64) {
                         var author_bytes: [32]u8 = undefined;
@@ -334,7 +334,7 @@ pub const ClientMsg = struct {
 
         if (filter_obj.get("kinds")) |kinds_val| {
             if (kinds_val == .array) {
-                var kinds_list: std.ArrayListUnmanaged(i32) = .{};
+                var kinds_list: std.ArrayListUnmanaged(i32) = .empty;
                 for (kinds_val.array.items) |kind_val| {
                     if (kind_val == .integer) {
                         try kinds_list.append(allocator, @intCast(kind_val.integer));
@@ -389,20 +389,20 @@ pub const ClientMsg = struct {
     }
 
     pub fn eventMsg(ev: *const Event, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"EVENT\",");
-        const event_json = try ev.serialize(buf[fbs.pos..]);
-        fbs.pos += event_json.len;
+        const event_json = try ev.serialize(buf[fbs.end..]);
+        fbs.end += event_json.len;
         try writer.writeAll("]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn reqMsg(sub_id: []const u8, filters: []const Filter, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"REQ\",\"");
         try writer.writeAll(sub_id);
@@ -410,24 +410,24 @@ pub const ClientMsg = struct {
 
         for (filters) |filter| {
             try writer.writeByte(',');
-            const filter_json = try filter.serialize(buf[fbs.pos..]);
-            fbs.pos += filter_json.len;
+            const filter_json = try filter.serialize(buf[fbs.end..]);
+            fbs.end += filter_json.len;
         }
 
         try writer.writeAll("]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn closeMsg(sub_id: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"CLOSE\",\"");
         try writer.writeAll(sub_id);
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -509,8 +509,8 @@ pub const RelayMsg = struct {
     }
 
     pub fn eventRaw(sub_id: []const u8, raw_json: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"EVENT\",\"");
         try writer.writeAll(sub_id);
@@ -518,12 +518,12 @@ pub const RelayMsg = struct {
         try writer.writeAll(raw_json);
         try writer.writeAll("]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn ok(event_id: *const [32]u8, success: bool, message: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"OK\",\"");
 
@@ -546,23 +546,23 @@ pub const RelayMsg = struct {
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn eose(sub_id: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"EOSE\",\"");
         try writer.writeAll(sub_id);
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn closed(sub_id: []const u8, message: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"CLOSED\",\"");
         try writer.writeAll(sub_id);
@@ -579,12 +579,12 @@ pub const RelayMsg = struct {
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn notice(message: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"NOTICE\",\"");
 
@@ -599,12 +599,12 @@ pub const RelayMsg = struct {
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn auth(challenge: *const [32]u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"AUTH\",\"");
 
@@ -614,12 +614,12 @@ pub const RelayMsg = struct {
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn count(sub_id: []const u8, count_val: u64, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"COUNT\",\"");
         try writer.writeAll(sub_id);
@@ -627,30 +627,30 @@ pub const RelayMsg = struct {
         try writer.print("{d}", .{count_val});
         try writer.writeAll("}]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn negMsg(sub_id: []const u8, payload: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"NEG-MSG\",\"");
         try writer.writeAll(sub_id);
         try writer.writeAll("\",\"");
 
         const hex_len = payload.len * 2;
-        if (fbs.pos + hex_len + 2 > buf.len) return error.NoSpaceLeft;
-        hex.encode(payload, buf[fbs.pos..][0..hex_len]);
-        fbs.pos += hex_len;
+        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
+        hex.encode(payload, buf[fbs.end..][0..hex_len]);
+        fbs.end += hex_len;
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn negErr(sub_id: []const u8, reason: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("[\"NEG-ERR\",\"");
         try writer.writeAll(sub_id);
@@ -667,7 +667,7 @@ pub const RelayMsg = struct {
 
         try writer.writeAll("\"]");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/negentropy.zig
+++ b/src/negentropy.zig
@@ -161,7 +161,7 @@ pub const VectorStorage = struct {
     allocator: std.mem.Allocator,
 
     pub fn init(allocator: std.mem.Allocator) VectorStorage {
-        return .{ .items = .{}, .allocator = allocator };
+        return .{ .items = .empty, .allocator = allocator };
     }
 
     pub fn deinit(self: *VectorStorage) void {
@@ -256,8 +256,8 @@ pub const Negentropy = struct {
         self.last_timestamp_in = 0;
         self.last_timestamp_out = 0;
 
-        var have_ids: std.ArrayListUnmanaged([ID_SIZE]u8) = .{};
-        var need_ids: std.ArrayListUnmanaged([ID_SIZE]u8) = .{};
+        var have_ids: std.ArrayListUnmanaged([ID_SIZE]u8) = .empty;
+        var need_ids: std.ArrayListUnmanaged([ID_SIZE]u8) = .empty;
 
         if (out.len == 0) return Error.BufferTooSmall;
         var pos: usize = 0;

--- a/src/nip04.zig
+++ b/src/nip04.zig
@@ -84,7 +84,7 @@ pub fn encrypt(
     defer allocator.free(ciphertext);
 
     var iv: [BLOCK_SIZE]u8 = undefined;
-    std.crypto.random.bytes(&iv);
+    @import("io.zig").randomBytes(&iv);
 
     aesCbcEncrypt(&shared_secret, &iv, padded, ciphertext);
 

--- a/src/nip05.zig
+++ b/src/nip05.zig
@@ -25,18 +25,18 @@ pub const Identifier = struct {
     }
 
     pub fn formatUrl(self: *const Identifier, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
         try writer.writeAll("https://");
         try writer.writeAll(self.domain);
         try writer.writeAll("/.well-known/nostr.json?name=");
         try percentEncode(writer, self.local_part);
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn formatDisplay(self: *const Identifier, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
         if (self.isRoot()) {
             try writer.writeAll(self.domain);
         } else {
@@ -44,7 +44,7 @@ pub const Identifier = struct {
             try writer.writeByte('@');
             try writer.writeAll(self.domain);
         }
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/nip10.zig
+++ b/src/nip10.zig
@@ -44,9 +44,9 @@ pub const Nip10 = struct {
     pub fn extractThreadInfo(json: []const u8, allocator: std.mem.Allocator) !ThreadInfo {
         var result = ThreadInfo{ .allocator = allocator };
         errdefer result.deinit();
-        var e_tags: std.ArrayListUnmanaged(ETagInfo) = .{};
+        var e_tags: std.ArrayListUnmanaged(ETagInfo) = .empty;
         defer e_tags.deinit(allocator);
-        var q_tags: std.ArrayListUnmanaged(QTagInfo) = .{};
+        var q_tags: std.ArrayListUnmanaged(QTagInfo) = .empty;
         defer q_tags.deinit(allocator);
 
         var iter = FullTagIterator.init(json, "tags") orelse return result;

--- a/src/nip46.zig
+++ b/src/nip46.zig
@@ -161,8 +161,8 @@ pub const Request = struct {
     }
 
     pub fn serialize(self: *const Request, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"id\":\"");
         try utils.writeJsonEscaped(writer, self.id);
@@ -211,7 +211,7 @@ pub const Request = struct {
         }
 
         try writer.writeAll("]}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -241,8 +241,8 @@ pub const Response = struct {
     }
 
     pub fn serialize(self: *const Response, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"id\":\"");
         try utils.writeJsonEscaped(writer, self.id);
@@ -263,7 +263,7 @@ pub const Response = struct {
         }
 
         try writer.writeAll("}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 
     pub fn isAuthChallenge(self: *const Response) bool {
@@ -303,7 +303,7 @@ pub const BunkerUri = struct {
         const query = after_prefix[query_start + 1 ..];
 
         var secret: ?[]const u8 = null;
-        var relays: std.ArrayListUnmanaged([]const u8) = .{};
+        var relays: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (relays.items) |r| allocator.free(r);
             relays.deinit(allocator);
@@ -341,8 +341,8 @@ pub const BunkerUri = struct {
     }
 
     pub fn format(self: *const BunkerUri, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("bunker://");
         var pk_hex: [64]u8 = undefined;
@@ -361,7 +361,7 @@ pub const BunkerUri = struct {
             try percentEncode(writer, s);
         }
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -395,7 +395,7 @@ pub const NostrConnectUri = struct {
         var name: ?[]const u8 = null;
         var url_field: ?[]const u8 = null;
         var image: ?[]const u8 = null;
-        var relays: std.ArrayListUnmanaged([]const u8) = .{};
+        var relays: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (relays.items) |r| allocator.free(r);
             relays.deinit(allocator);
@@ -454,8 +454,8 @@ pub const NostrConnectUri = struct {
     }
 
     pub fn format(self: *const NostrConnectUri, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("nostrconnect://");
         var pk_hex: [64]u8 = undefined;
@@ -492,7 +492,7 @@ pub const NostrConnectUri = struct {
             try percentEncode(writer, img);
         }
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/nip49.zig
+++ b/src/nip49.zig
@@ -57,10 +57,10 @@ pub fn encrypt(
     if (out.len < NCRYPTSEC_LEN) return Error.BufferTooSmall;
 
     var salt: [SALT_LEN]u8 = undefined;
-    std.crypto.random.bytes(&salt);
+    @import("io.zig").randomBytes(&salt);
 
     var nonce: [NONCE_LEN]u8 = undefined;
-    std.crypto.random.bytes(&nonce);
+    @import("io.zig").randomBytes(&nonce);
 
     var symmetric_key: [KEY_LEN]u8 = undefined;
     defer @memset(&symmetric_key, 0);
@@ -145,7 +145,7 @@ pub fn decrypt(
     const ciphertext = payload[2 + SALT_LEN + NONCE_LEN + 1 .. 2 + SALT_LEN + NONCE_LEN + 1 + KEY_LEN];
     const tag = payload[2 + SALT_LEN + NONCE_LEN + 1 + KEY_LEN ..][0..TAG_LEN];
 
-    const key_security: KeySecurity = std.meta.intToEnum(KeySecurity, key_security_byte) catch {
+    const key_security: KeySecurity = std.enums.fromInt(KeySecurity, key_security_byte) orelse {
         return Error.InvalidKeySecurity;
     };
 
@@ -229,7 +229,7 @@ test "nip49 all key security values roundtrip" {
     const allocator = std.testing.allocator;
 
     var secret_key: [32]u8 = undefined;
-    std.crypto.random.bytes(&secret_key);
+    @import("io.zig").randomBytes(&secret_key);
 
     const password = "test";
     const log_n: u6 = 4;
@@ -250,7 +250,7 @@ test "nip49 minimum buffer size" {
     const allocator = std.testing.allocator;
 
     var secret_key: [32]u8 = undefined;
-    std.crypto.random.bytes(&secret_key);
+    @import("io.zig").randomBytes(&secret_key);
 
     // Buffer too small should fail
     var small_buf: [NCRYPTSEC_LEN - 1]u8 = undefined;

--- a/src/nip59.zig
+++ b/src/nip59.zig
@@ -31,8 +31,8 @@ pub const Rumor = struct {
     tags: []const []const []const u8,
 
     pub fn serializeJson(self: *const Rumor, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"id\":\"");
         var id_hex: [64]u8 = undefined;
@@ -67,7 +67,7 @@ pub const Rumor = struct {
         try utils.writeJsonEscaped(writer, self.content);
         try writer.writeAll("\"}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -91,8 +91,8 @@ pub fn createRumor(
     const commitment_buf = try allocator.alloc(u8, 131072);
     defer allocator.free(commitment_buf);
 
-    var fbs = std.io.fixedBufferStream(commitment_buf);
-    const writer = fbs.writer();
+    var fbs = std.Io.Writer.fixed(commitment_buf);
+    const writer = &fbs;
 
     try writer.writeAll("[0,\"");
     var pk_hex: [64]u8 = undefined;
@@ -120,16 +120,16 @@ pub fn createRumor(
     try utils.writeJsonEscaped(writer, content);
     try writer.writeAll("\"]");
 
-    const commitment = fbs.getWritten();
+    const commitment = fbs.buffered();
     std.crypto.hash.sha2.Sha256.hash(commitment, &rumor.id, .{});
 
     return rumor;
 }
 
 fn randomPastTimestamp() i64 {
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     var random_bytes: [8]u8 = undefined;
-    std.crypto.random.bytes(&random_bytes);
+    @import("io.zig").randomBytes(&random_bytes);
     const random_offset = @as(i64, @intCast(std.mem.readInt(u64, &random_bytes, .little) % @as(u64, @intCast(TWO_DAYS_SECS))));
     return now - random_offset;
 }
@@ -148,8 +148,8 @@ fn signAndSerialize(
 
     const commitment_buf = try allocator.alloc(u8, 131072);
     defer allocator.free(commitment_buf);
-    var fbs = std.io.fixedBufferStream(commitment_buf);
-    const cwriter = fbs.writer();
+    var fbs = std.Io.Writer.fixed(commitment_buf);
+    const cwriter = &fbs;
 
     try cwriter.writeAll("[0,\"");
     var pk_hex: [64]u8 = undefined;
@@ -177,15 +177,15 @@ fn signAndSerialize(
     try utils.writeJsonEscaped(cwriter, content);
     try cwriter.writeAll("\"]");
 
-    const commitment = fbs.getWritten();
+    const commitment = fbs.buffered();
     std.crypto.hash.sha2.Sha256.hash(commitment, &id, .{});
 
     crypto.sign(&keypair.secret_key, &id, &sig) catch {
         return error.SignatureFailed;
     };
 
-    var out_fbs = std.io.fixedBufferStream(out_buf);
-    const writer = out_fbs.writer();
+    var out_fbs = std.Io.Writer.fixed(out_buf);
+    const writer = &out_fbs;
 
     try writer.writeAll("{\"id\":\"");
     var id_hex: [64]u8 = undefined;
@@ -223,7 +223,7 @@ fn signAndSerialize(
     try writer.writeAll(&sig_hex);
     try writer.writeAll("\"}");
 
-    return out_fbs.getWritten();
+    return out_fbs.buffered();
 }
 
 pub fn createSeal(
@@ -564,7 +564,7 @@ test "timestamps are randomized in past" {
     const sender = Keypair.generate();
     const recipient = Keypair.generate();
 
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     const rumor = try createRumor(1, "test", &[_][]const []const u8{}, now, &sender, allocator);
 
     var seal_buf: [65536]u8 = undefined;

--- a/src/nip86.zig
+++ b/src/nip86.zig
@@ -489,7 +489,7 @@ pub fn validateNip98Auth(auth_header: ?[]const u8, body: []const u8, request_url
         return AuthResult.fail("{\"error\":\"authorization event must be kind 27235\"}");
     }
 
-    const now = std.time.timestamp();
+    const now = @import("io.zig").timestamp();
     const created = event.createdAt();
     const time_diff = if (now > created) now - created else created - now;
     if (time_diff > 60) {

--- a/src/nwc.zig
+++ b/src/nwc.zig
@@ -228,7 +228,7 @@ pub const ConnectionUri = struct {
 
         var secret: ?[32]u8 = null;
         var lud16: ?[]const u8 = null;
-        var relays: std.ArrayListUnmanaged([]const u8) = .{};
+        var relays: std.ArrayListUnmanaged([]const u8) = .empty;
         errdefer {
             for (relays.items) |r| allocator.free(r);
             relays.deinit(allocator);
@@ -273,8 +273,8 @@ pub const ConnectionUri = struct {
     }
 
     pub fn format(self: *const ConnectionUri, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("nostr+walletconnect://");
         var pk_hex: [64]u8 = undefined;
@@ -298,7 +298,7 @@ pub const ConnectionUri = struct {
             try percentEncode(writer, l);
         }
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -437,8 +437,8 @@ pub const Request = struct {
     }
 
     pub fn serialize(self: *const Request, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"method\":\"");
         try writer.writeAll(self.method.toString());
@@ -569,7 +569,7 @@ pub const Request = struct {
         }
 
         try writer.writeAll("}}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -668,8 +668,8 @@ pub const Response = struct {
     }
 
     pub fn serialize(self: *const Response, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"result_type\":\"");
         try writer.writeAll(self.result_type.toString());
@@ -780,7 +780,7 @@ pub const Response = struct {
         }
 
         try writer.writeAll("}");
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -801,8 +801,8 @@ pub const Notification = struct {
     }
 
     pub fn serialize(self: *const Notification, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         try writer.writeAll("{\"notification_type\":\"");
         try writer.writeAll(self.notification_type.toString());
@@ -810,7 +810,7 @@ pub const Notification = struct {
         try serializeTransaction(writer, self.notification);
         try writer.writeAll("}}");
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 
@@ -842,15 +842,15 @@ pub const InfoEvent = struct {
     }
 
     pub fn serializeContent(self: *const InfoEvent, buf: []u8) ![]u8 {
-        var fbs = std.io.fixedBufferStream(buf);
-        const writer = fbs.writer();
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
 
         for (self.getCapabilities(), 0..) |cap, i| {
             if (i > 0) try writer.writeAll(" ");
             try writer.writeAll(cap.toString());
         }
 
-        return fbs.getWritten();
+        return fbs.buffered();
     }
 };
 

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Thread = std.Thread;
-const Mutex = Thread.Mutex;
+const Mutex = std.Io.Mutex;
 
 const ws = @import("ws/ws.zig");
 const Client = ws.Client;
@@ -146,11 +146,11 @@ pub const Pool = struct {
     pub fn initWithOptions(allocator: Allocator, options: PoolOptions) Pool {
         return .{
             .allocator = allocator,
-            .relays = .{},
+            .relays = .empty,
             .seen_events = .{},
             .message_queue = MessageQueue.initWithCapacity(allocator, options.queue_size),
             .subscriptions = .{},
-            .mutex = .{},
+            .mutex = .init,
             .options = options,
             .next_relay_idx = std.atomic.Value(usize).init(0),
             .active_workers = std.atomic.Value(usize).init(0),
@@ -181,8 +181,8 @@ pub const Pool = struct {
     }
 
     pub fn addRelay(self: *Pool, url: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.relays.items) |relay| {
             if (std.mem.eql(u8, relay.url, url)) {
@@ -205,8 +205,8 @@ pub const Pool = struct {
         var found = false;
 
         {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(@import("io.zig").io());
+            defer self.mutex.unlock(@import("io.zig").io());
 
             for (self.relays.items) |*relay| {
                 if (std.mem.eql(u8, relay.url, url)) {
@@ -223,8 +223,8 @@ pub const Pool = struct {
 
         if (thread_to_join) |t| t.join();
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.relays.items, 0..) |*relay, i| {
             if (std.mem.eql(u8, relay.url, url)) {
@@ -239,8 +239,8 @@ pub const Pool = struct {
     }
 
     pub fn connectAll(self: *Pool) !usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var connected: usize = 0;
         for (self.relays.items) |*relay| {
@@ -263,8 +263,8 @@ pub const Pool = struct {
         var thread_count: usize = 0;
 
         {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(@import("io.zig").io());
+            defer self.mutex.unlock(@import("io.zig").io());
 
             for (self.relays.items) |*relay| {
                 relay.should_stop.store(true, .release);
@@ -282,8 +282,8 @@ pub const Pool = struct {
             if (maybe_thread) |t| t.join();
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.relays.items) |*relay| {
             if (relay.client) |*c| c.close();
@@ -294,8 +294,8 @@ pub const Pool = struct {
     }
 
     pub fn getRelayStatus(self: *Pool, url: []const u8) ?RelayStatus {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.relays.items) |*relay| {
             if (std.mem.eql(u8, relay.url, url)) {
@@ -306,8 +306,8 @@ pub const Pool = struct {
     }
 
     pub fn connectedCount(self: *Pool) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var count: usize = 0;
         for (self.relays.items) |*relay| {
@@ -319,8 +319,8 @@ pub const Pool = struct {
     }
 
     pub fn relayCount(self: *Pool) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.relays.items.len;
     }
 
@@ -333,24 +333,24 @@ pub const Pool = struct {
         defer if (heap_buf) |buf| self.allocator.free(buf);
 
         if (required_len <= stack_buf.len) {
-            var fbs = std.io.fixedBufferStream(&stack_buf);
-            const writer = fbs.writer();
+            var fbs = std.Io.Writer.fixed(&stack_buf);
+            const writer = &fbs;
             writer.writeAll("[\"EVENT\",") catch return error.BufferTooSmall;
             writer.writeAll(event_json) catch return error.BufferTooSmall;
             writer.writeAll("]") catch return error.BufferTooSmall;
-            msg = fbs.getWritten();
+            msg = fbs.buffered();
         } else {
             heap_buf = try self.allocator.alloc(u8, required_len);
-            var fbs = std.io.fixedBufferStream(heap_buf.?);
-            const writer = fbs.writer();
+            var fbs = std.Io.Writer.fixed(heap_buf.?);
+            const writer = &fbs;
             try writer.writeAll("[\"EVENT\",");
             try writer.writeAll(event_json);
             try writer.writeAll("]");
-            msg = fbs.getWritten();
+            msg = fbs.buffered();
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var results = try self.allocator.alloc(PublishResult, self.relays.items.len);
         var result_idx: usize = 0;
@@ -399,24 +399,24 @@ pub const Pool = struct {
         defer if (heap_buf) |buf| self.allocator.free(buf);
 
         if (required_len <= stack_buf.len) {
-            var fbs = std.io.fixedBufferStream(&stack_buf);
-            const writer = fbs.writer();
+            var fbs = std.Io.Writer.fixed(&stack_buf);
+            const writer = &fbs;
             writer.writeAll("[\"EVENT\",") catch return error.BufferTooSmall;
             writer.writeAll(event_json) catch return error.BufferTooSmall;
             writer.writeAll("]") catch return error.BufferTooSmall;
-            msg = fbs.getWritten();
+            msg = fbs.buffered();
         } else {
             heap_buf = try self.allocator.alloc(u8, required_len);
-            var fbs = std.io.fixedBufferStream(heap_buf.?);
-            const writer = fbs.writer();
+            var fbs = std.Io.Writer.fixed(heap_buf.?);
+            const writer = &fbs;
             try writer.writeAll("[\"EVENT\",");
             try writer.writeAll(event_json);
             try writer.writeAll("]");
-            msg = fbs.getWritten();
+            msg = fbs.buffered();
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         const relay_count = self.relays.items.len;
         if (relay_count == 0) return null;
@@ -447,8 +447,8 @@ pub const Pool = struct {
         var msg_buf: [65536]u8 = undefined;
         const msg = try ClientMsg.reqMsg(sub_id, filters, &msg_buf);
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var owned_filters = try self.allocator.alloc(Filter, filters.len);
         errdefer self.allocator.free(owned_filters);
@@ -475,8 +475,8 @@ pub const Pool = struct {
         var msg_buf: [256]u8 = undefined;
         const msg = try ClientMsg.closeMsg(sub_id, &msg_buf);
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.subscriptions.fetchRemove(sub_id)) |entry| {
             self.allocator.free(entry.key);
@@ -495,8 +495,8 @@ pub const Pool = struct {
     }
 
     pub fn startReceiving(self: *Pool) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         for (self.relays.items) |*relay| {
             if (relay.getStatus() == .connected and relay.thread == null) {
@@ -597,14 +597,14 @@ pub const Pool = struct {
     }
 
     fn isDuplicate(self: *Pool, event_id: *const [32]u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.seen_events.contains(event_id.*);
     }
 
     fn tryMarkSeen(self: *Pool, event_id: *const [32]u8) !bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.seen_events.contains(event_id.*)) {
             return false;
@@ -627,13 +627,13 @@ pub const Pool = struct {
             }
         }
 
-        try self.seen_events.put(self.allocator, event_id.*, std.time.timestamp());
+        try self.seen_events.put(self.allocator, event_id.*, @import("io.zig").timestamp());
         return true;
     }
 
     fn markSeen(self: *Pool, event_id: *const [32]u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.seen_events.count() >= self.options.dedup_cache_size) {
             var oldest_key: ?[32]u8 = null;
@@ -652,24 +652,24 @@ pub const Pool = struct {
             }
         }
 
-        try self.seen_events.put(self.allocator, event_id.*, std.time.timestamp());
+        try self.seen_events.put(self.allocator, event_id.*, @import("io.zig").timestamp());
     }
 
     pub fn clearSeenEvents(self: *Pool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         self.seen_events.clearRetainingCapacity();
     }
 
     pub fn seenCount(self: *Pool) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.seen_events.count();
     }
 
     pub fn getRelays(self: *Pool) ![]RelayInfo {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var infos = try self.allocator.alloc(RelayInfo, self.relays.items.len);
         errdefer self.allocator.free(infos);
@@ -720,14 +720,14 @@ pub const Pool = struct {
         }
 
         const timeout_ns = timeout_ms * std.time.ns_per_ms;
-        const deadline = std.time.nanoTimestamp() + @as(i128, timeout_ns);
+        const deadline = @import("io.zig").nanoTimestamp() + @as(i128, timeout_ns);
         var eose_count: usize = 0;
 
-        while (std.time.nanoTimestamp() < deadline) {
+        while (@import("io.zig").nanoTimestamp() < deadline) {
             const current_connected = self.connectedCount();
             if (current_connected == 0 or eose_count >= current_connected) break;
 
-            const remaining: u64 = @intCast(@max(0, deadline - std.time.nanoTimestamp()));
+            const remaining: u64 = @intCast(@max(0, deadline - @import("io.zig").nanoTimestamp()));
             const msg = self.receiveWithTimeout(@min(remaining, 100 * std.time.ns_per_ms)) orelse continue;
             defer self.freeMessage(msg);
 
@@ -751,8 +751,8 @@ pub const Pool = struct {
         var thread_count: usize = 0;
 
         {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(@import("io.zig").io());
+            defer self.mutex.unlock(@import("io.zig").io());
 
             for (self.relays.items) |*relay| {
                 relay.should_stop.store(true, .release);
@@ -770,8 +770,8 @@ pub const Pool = struct {
             if (maybe_thread) |t| t.join();
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         for (self.relays.items) |*relay| {
             relay.should_stop.store(false, .release);
         }

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -82,7 +82,7 @@ pub const Relay = struct {
     last_message_time: i64,
     last_ping_time: i64,
     awaiting_pong: bool,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
 
     const Self = @This();
 
@@ -99,13 +99,13 @@ pub const Relay = struct {
             .last_message_time = 0,
             .last_ping_time = 0,
             .awaiting_pong = false,
-            .mutex = .{},
+            .mutex = .init,
         };
     }
 
     pub fn deinit(self: *Self) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         self.closeInternal();
         var iter = self.subscriptions.iterator();
@@ -115,8 +115,8 @@ pub const Relay = struct {
     }
 
     pub fn connect(self: *Self) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.state == .connected) return RelayError.AlreadyConnected;
 
@@ -137,14 +137,14 @@ pub const Relay = struct {
         self.client = client;
         self.state = .connected;
         self.reconnect_attempts = 0;
-        self.last_message_time = std.time.timestamp();
+        self.last_message_time = @import("io.zig").timestamp();
         self.last_ping_time = 0;
         self.awaiting_pong = false;
     }
 
     pub fn disconnect(self: *Self) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         self.closeInternal();
     }
 
@@ -158,16 +158,16 @@ pub const Relay = struct {
 
     pub fn reconnect(self: *Self) !void {
         while (true) {
-            self.mutex.lock();
+            self.mutex.lockUncancelable(@import("io.zig").io());
             const config = self.config;
             const current_attempts = self.reconnect_attempts;
 
             if (!config.auto_reconnect) {
-                self.mutex.unlock();
+                self.mutex.unlock(@import("io.zig").io());
                 return RelayError.ConnectionFailed;
             }
             if (config.reconnect_max_attempts > 0 and current_attempts >= config.reconnect_max_attempts) {
-                self.mutex.unlock();
+                self.mutex.unlock(@import("io.zig").io());
                 return RelayError.ConnectionFailed;
             }
 
@@ -177,17 +177,17 @@ pub const Relay = struct {
                 c.close();
                 self.client = null;
             }
-            self.mutex.unlock();
+            self.mutex.unlock(@import("io.zig").io());
 
             const delay = calculateBackoff(config.reconnect_base_delay_ms, config.reconnect_max_delay_ms, current_attempts);
-            std.time.sleep(delay * std.time.ns_per_ms);
+            std.Io.sleep(@import("io.zig").io(), .{ .nanoseconds = @intCast(delay * std.time.ns_per_ms) }, .awake) catch {};
 
-            self.mutex.lock();
+            self.mutex.lockUncancelable(@import("io.zig").io());
             if (self.state != .reconnecting) {
-                self.mutex.unlock();
+                self.mutex.unlock(@import("io.zig").io());
                 return;
             }
-            self.mutex.unlock();
+            self.mutex.unlock(@import("io.zig").io());
 
             self.connect() catch {
                 continue;
@@ -199,8 +199,8 @@ pub const Relay = struct {
     }
 
     fn resubscribeAll(self: *Self) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         var iter = self.subscriptions.iterator();
         while (iter.next()) |entry| {
@@ -214,8 +214,8 @@ pub const Relay = struct {
     }
 
     pub fn subscribe(self: *Self, sub_id: []const u8, filters: []const Filter) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.state != .connected) return RelayError.NotConnected;
         if (self.subscriptions.count() >= self.config.max_subscriptions) {
@@ -248,15 +248,15 @@ pub const Relay = struct {
             .id = id_copy,
             .filters = filters_copy,
             .eose_received = false,
-            .created_at = std.time.timestamp(),
+            .created_at = @import("io.zig").timestamp(),
             .event_count = 0,
             .allocator = self.allocator,
         });
     }
 
     pub fn unsubscribe(self: *Self, sub_id: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.state != .connected) return RelayError.NotConnected;
 
@@ -274,8 +274,8 @@ pub const Relay = struct {
     }
 
     pub fn publish(self: *Self, event: *const Event) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.state != .connected) return RelayError.NotConnected;
 
@@ -290,27 +290,27 @@ pub const Relay = struct {
     }
 
     pub fn receive(self: *Self) !?RelayMessage {
-        self.mutex.lock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
         if (self.state != .connected) {
-            self.mutex.unlock();
+            self.mutex.unlock(@import("io.zig").io());
             return RelayError.NotConnected;
         }
         var client = self.client orelse {
-            self.mutex.unlock();
+            self.mutex.unlock(@import("io.zig").io());
             return RelayError.NotConnected;
         };
-        self.mutex.unlock();
+        self.mutex.unlock(@import("io.zig").io());
 
         const ws_msg = client.recvMessage() catch |err| {
             switch (err) {
                 error.EndOfStream, error.ConnectionResetByPeer => {
-                    self.mutex.lock();
+                    self.mutex.lockUncancelable(@import("io.zig").io());
                     if (self.client) |*c| {
                         c.close();
                         self.client = null;
                     }
                     self.state = .disconnected;
-                    self.mutex.unlock();
+                    self.mutex.unlock(@import("io.zig").io());
                     if (self.config.auto_reconnect) {
                         self.reconnect() catch {};
                     }
@@ -321,10 +321,10 @@ pub const Relay = struct {
         };
         defer ws_msg.deinit();
 
-        self.mutex.lock();
-        self.last_message_time = std.time.timestamp();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        self.last_message_time = @import("io.zig").timestamp();
         self.awaiting_pong = false;
-        self.mutex.unlock();
+        self.mutex.unlock(@import("io.zig").io());
 
         return self.parseRelayMessage(ws_msg.payload);
     }
@@ -381,33 +381,33 @@ pub const Relay = struct {
                 }
 
                 if (sub_id) |sid| {
-                    self.mutex.lock();
+                    self.mutex.lockUncancelable(@import("io.zig").io());
                     if (self.subscriptions.getPtr(sid)) |sub| {
                         sub.event_count += 1;
                     }
-                    self.mutex.unlock();
+                    self.mutex.unlock(@import("io.zig").io());
                 }
             }
 
             if (parsed.msg_type == .eose) {
                 if (sub_id) |sid| {
-                    self.mutex.lock();
+                    self.mutex.lockUncancelable(@import("io.zig").io());
                     if (self.subscriptions.getPtr(sid)) |sub| {
                         sub.eose_received = true;
                     }
-                    self.mutex.unlock();
+                    self.mutex.unlock(@import("io.zig").io());
                 }
             }
 
             if (parsed.msg_type == .closed and arr.len > 2 and arr[2] == .string) {
                 msg_text = try self.allocator.dupe(u8, arr[2].string);
                 if (sub_id) |sid| {
-                    self.mutex.lock();
+                    self.mutex.lockUncancelable(@import("io.zig").io());
                     if (self.subscriptions.fetchRemove(sid)) |kv| {
                         var sub = kv.value;
                         sub.deinit();
                     }
-                    self.mutex.unlock();
+                    self.mutex.unlock(@import("io.zig").io());
                 }
             }
 
@@ -435,8 +435,8 @@ pub const Relay = struct {
     }
 
     pub fn sendPing(self: *Self) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
 
         if (self.state != .connected) return RelayError.NotConnected;
         if (self.client) |*c| {
@@ -446,33 +446,33 @@ pub const Relay = struct {
             defer self.allocator.free(buf);
             _ = frame.encode(buf, 0);
             c.writeAll(buf) catch return RelayError.SendFailed;
-            self.last_ping_time = std.time.timestamp();
+            self.last_ping_time = @import("io.zig").timestamp();
             self.awaiting_pong = true;
         }
     }
 
     pub fn checkTimeouts(self: *Self) !void {
-        self.mutex.lock();
-        const now = std.time.timestamp();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        const now = @import("io.zig").timestamp();
         const last_msg = self.last_message_time;
         const last_ping = self.last_ping_time;
         const awaiting = self.awaiting_pong;
         const config = self.config;
         const state = self.state;
-        self.mutex.unlock();
+        self.mutex.unlock(@import("io.zig").io());
 
         if (state != .connected) return;
 
         if (awaiting) {
             const pong_timeout_sec = @as(i64, @intCast(config.pong_timeout_ms)) / 1000;
             if (now - last_ping > pong_timeout_sec) {
-                self.mutex.lock();
+                self.mutex.lockUncancelable(@import("io.zig").io());
                 self.state = .disconnected;
                 if (self.client) |*c| {
                     c.close();
                     self.client = null;
                 }
-                self.mutex.unlock();
+                self.mutex.unlock(@import("io.zig").io());
                 if (config.auto_reconnect) {
                     try self.reconnect();
                 }
@@ -487,8 +487,8 @@ pub const Relay = struct {
     }
 
     pub fn getState(self: *Self) ConnectionState {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.state;
     }
 
@@ -497,26 +497,26 @@ pub const Relay = struct {
     }
 
     pub fn getSubscription(self: *Self, sub_id: []const u8) ?Subscription {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.subscriptions.get(sub_id);
     }
 
     pub fn getSubscriptionCount(self: *Self) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.subscriptions.count();
     }
 
     pub fn hasSubscription(self: *Self, sub_id: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         return self.subscriptions.contains(sub_id);
     }
 
     pub fn isEoseReceived(self: *Self, sub_id: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
         if (self.subscriptions.get(sub_id)) |sub| {
             return sub.eose_received;
         }

--- a/src/relay_groups.zig
+++ b/src/relay_groups.zig
@@ -142,7 +142,7 @@ pub const GroupAdmins = struct {
     pub fn init(allocator: std.mem.Allocator) GroupAdmins {
         return .{
             .group_id = "",
-            .admins = .{},
+            .admins = .empty,
             .allocator = allocator,
         };
     }
@@ -179,7 +179,7 @@ pub const GroupAdmins = struct {
             const pubkey = try allocator.dupe(u8, entry.pubkey);
             errdefer allocator.free(pubkey);
 
-            var roles_list: std.ArrayListUnmanaged([]const u8) = .{};
+            var roles_list: std.ArrayListUnmanaged([]const u8) = .empty;
             errdefer {
                 for (roles_list.items) |r| allocator.free(r);
                 roles_list.deinit(allocator);
@@ -218,7 +218,7 @@ pub const GroupMembers = struct {
     pub fn init(allocator: std.mem.Allocator) GroupMembers {
         return .{
             .group_id = "",
-            .members = .{},
+            .members = .empty,
             .allocator = allocator,
         };
     }
@@ -280,7 +280,7 @@ pub const GroupRoles = struct {
     pub fn init(allocator: std.mem.Allocator) GroupRoles {
         return .{
             .group_id = "",
-            .roles = .{},
+            .roles = .empty,
             .allocator = allocator,
         };
     }

--- a/src/relay_metadata.zig
+++ b/src/relay_metadata.zig
@@ -31,7 +31,7 @@ pub const RelayList = struct {
 
     pub fn init(allocator: std.mem.Allocator) RelayList {
         return .{
-            .relays = .{},
+            .relays = .empty,
             .allocator = allocator,
         };
     }

--- a/src/root.zig
+++ b/src/root.zig
@@ -44,6 +44,7 @@
 //! - `classified_listing.zig` - NIP-99 classified listings
 //! - `nip04.zig` - NIP-04 Encrypted Direct Messages (deprecated)
 
+pub const io = @import("io.zig");
 pub const crypto = @import("crypto.zig");
 pub const http_auth = @import("http_auth.zig");
 pub const negentropy = @import("negentropy.zig");

--- a/src/signer.zig
+++ b/src/signer.zig
@@ -113,7 +113,7 @@ pub const LocalSigner = struct {
     /// Call `deinit()` when done with the signer.
     pub fn generate() Error!LocalSigner {
         var secret_key: [32]u8 = undefined;
-        std.crypto.random.bytes(&secret_key);
+        @import("io.zig").randomBytes(&secret_key);
         var public_key: [32]u8 = undefined;
         crypto.getPublicKey(&secret_key, &public_key) catch {
             // Zero the secret key before returning on error
@@ -181,7 +181,7 @@ test "LocalSigner generate and sign" {
     try std.testing.expect(!std.mem.eql(u8, &pubkey, &[_]u8{0} ** 32));
 
     var message: [32]u8 = undefined;
-    std.crypto.random.bytes(&message);
+    @import("io.zig").randomBytes(&message);
     var sig: [64]u8 = undefined;
     try local.sign(&message, &sig);
 
@@ -194,7 +194,7 @@ test "LocalSigner from secret key" {
     defer event_mod.cleanup();
 
     var secret_key: [32]u8 = undefined;
-    std.crypto.random.bytes(&secret_key);
+    @import("io.zig").randomBytes(&secret_key);
 
     var local = try LocalSigner.fromSecretKey(secret_key);
     defer local.deinit();
@@ -217,7 +217,7 @@ test "Signer interface with LocalSigner" {
     try std.testing.expectEqual(SignerType.local, s.signer_type);
 
     var message: [32]u8 = undefined;
-    std.crypto.random.bytes(&message);
+    @import("io.zig").randomBytes(&message);
     var sig: [64]u8 = undefined;
     try s.sign(&message, &sig);
 
@@ -260,7 +260,7 @@ test "CallbackSigner with custom implementation" {
     };
 
     var secret_key: [32]u8 = undefined;
-    std.crypto.random.bytes(&secret_key);
+    @import("io.zig").randomBytes(&secret_key);
     var public_key: [32]u8 = undefined;
     crypto.getPublicKey(&secret_key, &public_key) catch unreachable;
 
@@ -275,7 +275,7 @@ test "CallbackSigner with custom implementation" {
     try std.testing.expectEqual(SignerType.browser, s.signer_type);
 
     var message: [32]u8 = undefined;
-    std.crypto.random.bytes(&message);
+    @import("io.zig").randomBytes(&message);
     var sig: [64]u8 = undefined;
     try s.sign(&message, &sig);
 

--- a/src/tags.zig
+++ b/src/tags.zig
@@ -25,7 +25,7 @@ pub const TagIndex = struct {
     pub fn init(allocator: std.mem.Allocator) TagIndex {
         var entries: [52]std.ArrayListUnmanaged(TagValue) = undefined;
         for (&entries) |*e| {
-            e.* = .{};
+            e.* = .empty;
         }
         return .{ .entries = entries, .allocator = allocator };
     }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -398,7 +398,7 @@ pub fn searchMatches(query: []const u8, content: []const u8) bool {
 }
 
 pub fn percentDecode(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
-    var result: std.ArrayListUnmanaged(u8) = .{};
+    var result: std.ArrayListUnmanaged(u8) = .empty;
     errdefer result.deinit(allocator);
 
     var i: usize = 0;

--- a/src/ws/client.zig
+++ b/src/ws/client.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const mem = std.mem;
+const io_mod = @import("../io.zig");
 const Allocator = mem.Allocator;
 
 const handshake = @import("handshake.zig");
@@ -70,14 +71,15 @@ pub const Client = struct {
             .sec = @intCast(seconds),
             .usec = @intCast(microseconds),
         };
-        std.posix.setsockopt(self.tcp_stream.handle, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeval)) catch {};
+        std.posix.setsockopt(self.tcp_stream.socket.handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeval)) catch {};
     }
 
     pub fn connect(allocator: Allocator, uri: []const u8) !Self {
         const parsed = try Uri.parse(uri);
 
-        const tcp_stream = try net.tcpConnectToHost(allocator, parsed.host, parsed.port);
-        errdefer tcp_stream.close();
+        const host_name = try net.HostName.init(parsed.host);
+        const tcp_stream = try host_name.connect(io_mod.io(), parsed.port, .{ .mode = .stream });
+        errdefer tcp_stream.close(io_mod.io());
 
         var ssl_stream: ?ssl.SslStream = null;
         if (parsed.is_tls) {
@@ -104,7 +106,7 @@ pub const Client = struct {
         if (self.ssl_stream) |*s| {
             s.close();
         } else {
-            self.tcp_stream.close();
+            self.tcp_stream.close(io_mod.io());
         }
     }
 
@@ -140,7 +142,7 @@ pub const Client = struct {
         if (self.ssl_stream) |*s| {
             return s.read(buffer);
         } else {
-            return self.tcp_stream.read(buffer);
+            return std.posix.read(self.tcp_stream.socket.handle, buffer);
         }
     }
 
@@ -148,7 +150,10 @@ pub const Client = struct {
         if (self.ssl_stream) |*s| {
             try s.writeAll(data);
         } else {
-            try self.tcp_stream.writeAll(data);
+            var wbuf: [4096]u8 = undefined;
+            var sw = self.tcp_stream.writer(io_mod.io(), &wbuf);
+            try sw.interface.writeAll(data);
+            try sw.interface.flush();
         }
     }
 

--- a/src/ws/frame.zig
+++ b/src/ws/frame.zig
@@ -204,7 +204,7 @@ pub const Frame = struct {
 
     fn maskingKey() [4]u8 {
         var masking_key: [4]u8 = undefined;
-        std.crypto.random.bytes(&masking_key);
+        @import("../io.zig").randomBytes(&masking_key);
         return masking_key;
     }
 

--- a/src/ws/handshake.zig
+++ b/src/ws/handshake.zig
@@ -18,7 +18,7 @@ pub fn secKey() [24]u8 {
     }
     var buf: [16]u8 = undefined;
     var ret: [24]u8 = undefined;
-    std.crypto.random.bytes(&buf);
+    @import("../io.zig").randomBytes(&buf);
     const encoded = base64Encoder.encode(&ret, &buf);
     assert(encoded.len == ret.len);
     return ret;

--- a/src/ws/ssl.zig
+++ b/src/ws/ssl.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const mem = std.mem;
 const Allocator = mem.Allocator;
 
@@ -65,7 +65,7 @@ pub const SslStream = struct {
             return error.SslContextFailed;
         }
 
-        if (c.SSL_set_fd(ssl, tcp_stream.handle) != 1) {
+        if (c.SSL_set_fd(ssl, tcp_stream.socket.handle) != 1) {
             return error.SslSetFdFailed;
         }
 
@@ -112,6 +112,6 @@ pub const SslStream = struct {
         _ = c.SSL_shutdown(self.ssl);
         c.SSL_free(self.ssl);
         c.SSL_CTX_free(self.ctx);
-        self.tcp_stream.close();
+        self.tcp_stream.close(@import("../io.zig").io());
     }
 };

--- a/src/ws/stream.zig
+++ b/src/ws/stream.zig
@@ -335,10 +335,22 @@ pub fn client(
 
 const testing = std.testing;
 
+const SliceReader = struct {
+    data: []const u8,
+    pos: usize = 0,
+
+    fn read(self: *SliceReader, buf: []u8) !usize {
+        const n = @min(buf.len, self.data.len - self.pos);
+        @memcpy(buf[0..n], self.data[self.pos..][0..n]);
+        self.pos += n;
+        return n;
+    }
+};
+
 test "reader read close frame" {
     var input = [_]u8{ 0x88, 0x02, 0x03, 0xe8 };
-    var inner_stm = std.io.fixedBufferStream(&input);
-    var rdr = reader(testing.allocator, inner_stm.reader());
+    var inner_stm = SliceReader{ .data = &input };
+    var rdr = reader(testing.allocator, &inner_stm);
     var frame = try rdr.frame();
     defer frame.deinit();
 
@@ -352,8 +364,8 @@ test "reader read close frame" {
 
 test "reader read masked close frame with payload" {
     var input = [_]u8{ 0x88, 0x87, 0xa, 0xb, 0xc, 0xd, 0x09, 0xe2, 0x0d, 0x0f, 0x09, 0x0f, 0x09 };
-    var inner_stm = std.io.fixedBufferStream(&input);
-    var rdr = reader(testing.allocator, inner_stm.reader());
+    var inner_stm = SliceReader{ .data = &input };
+    var rdr = reader(testing.allocator, &inner_stm);
     var frame = try rdr.frame();
     defer frame.deinit();
 

--- a/src/zap_goal.zig
+++ b/src/zap_goal.zig
@@ -30,13 +30,13 @@ pub const ZapGoal = struct {
         return .{
             .content = "",
             .amount = 0,
-            .relays = .{},
+            .relays = .empty,
             .closed_at = null,
             .image = null,
             .summary = null,
             .linked_url = null,
             .linked_address = null,
-            .beneficiaries = .{},
+            .beneficiaries = .empty,
             .allocator = allocator,
         };
     }
@@ -151,7 +151,7 @@ pub const ZapGoal = struct {
 
     pub fn isClosed(self: *const ZapGoal) bool {
         if (self.closed_at) |closed| {
-            return std.time.timestamp() > closed;
+            return @import("io.zig").timestamp() > closed;
         }
         return false;
     }


### PR DESCRIPTION
Migrates libnostr-z from Zig 0.15 to Zig 0.16 (stable).

## Changes
- **Time/random via `Io`**: 0.16 moved time and randomness behind the new `std.Io` interface. Added `src/io.zig` with a process-global blocking `std.Io.Threaded` and `timestamp()` / `nanoTimestamp()` / `randomBytes()` helpers, so the public API stays unchanged. Randomness still flows through a per-thread ChaCha CSPRNG seeded from OS entropy (equivalent to the old `std.crypto.random`).
- **Writer overhaul**: `std.io.fixedBufferStream` + `.getWritten()` → `std.Io.Writer.fixed` + `.buffered()` (~50 sites).
- **Sync**: `std.Thread.Mutex`/`Condition` → `std.Io.Mutex`/`Condition`.
- **Collections**: `ArrayListUnmanaged`/`HashMapUnmanaged` `.{}` → `.empty`.
- **Misc**: `std.meta.intToEnum` → `std.enums.fromInt`; `std.net` → `std.Io.net`; `std.time.sleep` → `std.Io.sleep`.
- **Deps**: noscrypt bumped to v0.1.14 (Zig 0.16 build).
- README badge Zig 0.15 → 0.16; 0.15 users pinned to the `v0.2.0` release.

## Testing
`zig build test` (Zig 0.16): 644/644 tests pass.

Verified independently: the CSPRNG path is OS-seeded ChaCha (not the insecure filler), and `timestamp()` returns real unix epoch seconds.