### PR TITLE
Fix ws/relay client build under Zig 0.16

### DIFF
--- a/src/relay.zig
+++ b/src/relay.zig
@@ -326,7 +326,7 @@ pub const Relay = struct {
         self.awaiting_pong = false;
         self.mutex.unlock(@import("io.zig").io());
 
-        return self.parseRelayMessage(ws_msg.payload);
+        return try self.parseRelayMessage(ws_msg.payload);
     }
 
     fn parseRelayMessage(self: *Self, payload: []const u8) !RelayMessage {

--- a/src/ws/ssl.zig
+++ b/src/ws/ssl.zig
@@ -8,6 +8,12 @@ const c = @cImport({
     @cInclude("openssl/err.h");
 });
 
+// Defined directly rather than via c.SSL_OP_NO_TICKET: translate-c renders
+// OpenSSL's SSL_OP_BIT(n) macro as a u64 shift amount, which fails to compile
+// under Zig 0.16 (shift counts must fit the operand width). The value is stable
+// ABI: SSL_OP_NO_TICKET == SSL_OP_BIT(14) == 1 << 14.
+const SSL_OP_NO_TICKET = 0x00004000;
+
 pub const SslError = error{
     SslInitFailed,
     SslContextFailed,
@@ -35,7 +41,7 @@ pub const SslStream = struct {
             return error.SslContextFailed;
         }
 
-        _ = c.SSL_CTX_set_options(ctx, c.SSL_OP_NO_TICKET);
+        _ = c.SSL_CTX_set_options(ctx, SSL_OP_NO_TICKET);
 
         if (c.SSL_CTX_set_default_verify_paths(ctx) != 1) {
             return error.SslContextFailed;


### PR DESCRIPTION
The WS client (`ws/ssl.zig`) and relay client (`relay.zig`) did not compile under Zig 0.16. No in-tree consumer exercised them (they are only analyzed when referenced), so the breakage was latent until a downstream CLI built on the relay client surfaced both.

## Fixes

- **`ws/ssl.zig`** — `c.SSL_OP_NO_TICKET` pulls in OpenSSL's `SSL_OP_BIT(n)` macro, which translate-c renders as a `u64` shift amount; Zig 0.16 rejects that (shift counts must fit the operand width). Define the constant directly (`SSL_OP_NO_TICKET == SSL_OP_BIT(14) == 1 << 14 == 0x4000`, stable ABI) so the bad cimport decl is never referenced.
- **`relay.zig`** — `receive()` returns `!?RelayMessage` but `return self.parseRelayMessage(...)` yields `!RelayMessage`, which won't coerce. Add `try`.

## Validated

A downstream CLI now builds against this branch and round-trips EVENT/REQ against a live relay (publish, subscribe, tag-filtered query, EOSE).

## Known follow-up (not in this PR)

`receive()` does `defer ws_msg.deinit()` (freeing the payload) before returning, but the parsed `RelayMessage.event`'s string fields (e.g. `raw_json`) point into that payload, so reading `msg.event` after `receive()` returns is a use-after-free. The owned `msg.raw` is safe. `parseRelayMessage` should dupe the event's backing bytes into the `RelayMessage` allocator. Filing separately.