### PR TITLE
Add compile-coverage guard; fix event use-after-free and remaining 0.16 breakage

### DIFF
--- a/src/event.zig
+++ b/src/event.zig
@@ -61,6 +61,7 @@ pub const Event = struct {
     created_at_val: i64,
     kind_val: i32,
     raw_json: []const u8,
+    owns_raw_json: bool = false,
 
     d_tag_val: ?[]const u8 = null,
     expiration_val: ?i64 = null,
@@ -72,6 +73,14 @@ pub const Event = struct {
 
     pub fn parse(json: []const u8) Error!Event {
         return parseWithAllocator(json, std.heap.page_allocator);
+    }
+
+    pub fn parseWithAllocatorOwned(json: []const u8, allocator: std.mem.Allocator) !Event {
+        const owned = try allocator.dupe(u8, json);
+        errdefer allocator.free(owned);
+        var event = try parseWithAllocator(owned, allocator);
+        event.owns_raw_json = true;
+        return event;
     }
 
     pub fn parseWithAllocator(json: []const u8, allocator: std.mem.Allocator) Error!Event {
@@ -240,6 +249,7 @@ pub const Event = struct {
     pub fn deinit(self: *Event) void {
         self.e_tags.deinit(self.allocator);
         self.tags.deinit();
+        if (self.owns_raw_json) self.allocator.free(self.raw_json);
     }
 };
 

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -737,7 +737,10 @@ pub const Pool = struct {
                 eose_count += 1;
             } else if (parsed.msg_type == .event) {
                 if (self.parseEventFromMessage(msg.data)) |event_data| {
-                    var event = Event.parseWithAllocatorOwned(event_data, self.allocator) catch continue;
+                    var event = Event.parseWithAllocatorOwned(event_data, self.allocator) catch |err| switch (err) {
+                        error.OutOfMemory => return err,
+                        else => continue,
+                    };
                     errdefer event.deinit();
                     try events.append(self.allocator, event);
                 }

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -737,7 +737,8 @@ pub const Pool = struct {
                 eose_count += 1;
             } else if (parsed.msg_type == .event) {
                 if (self.parseEventFromMessage(msg.data)) |event_data| {
-                    const event = Event.parseWithAllocator(event_data, self.allocator) catch continue;
+                    var event = Event.parseWithAllocatorOwned(event_data, self.allocator) catch continue;
+                    errdefer event.deinit();
                     try events.append(self.allocator, event);
                 }
             }

--- a/src/pool.zig
+++ b/src/pool.zig
@@ -713,10 +713,10 @@ pub const Pool = struct {
         try self.subscribe(sub_id, filters);
         defer self.unsubscribe(sub_id) catch {};
 
-        var events = std.ArrayList(Event).init(self.allocator);
+        var events: std.ArrayList(Event) = .empty;
         errdefer {
             for (events.items) |*e| e.deinit();
-            events.deinit();
+            events.deinit(self.allocator);
         }
 
         const timeout_ns = timeout_ms * std.time.ns_per_ms;
@@ -738,12 +738,12 @@ pub const Pool = struct {
             } else if (parsed.msg_type == .event) {
                 if (self.parseEventFromMessage(msg.data)) |event_data| {
                     const event = Event.parseWithAllocator(event_data, self.allocator) catch continue;
-                    try events.append(event);
+                    try events.append(self.allocator, event);
                 }
             }
         }
 
-        return events.toOwnedSlice();
+        return events.toOwnedSlice(self.allocator);
     }
 
     fn stopReceiving(self: *Pool) void {

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -376,7 +376,11 @@ pub const Relay = struct {
             }
 
             if (parsed.msg_type == .event and arr.len > 2) {
-                if (findEventJson(payload)) |event_json| {
+                // Parse out of raw_copy, not payload: the Event's string fields
+                // (raw_json, content) borrow their backing slice, and payload is
+                // freed by receive() before the RelayMessage is used. raw_copy is
+                // owned by the RelayMessage and lives until its deinit.
+                if (findEventJson(raw_copy)) |event_json| {
                     event_obj = Event.parseWithAllocator(event_json, self.allocator) catch null;
                 }
 
@@ -464,7 +468,7 @@ pub const Relay = struct {
         if (state != .connected) return;
 
         if (awaiting) {
-            const pong_timeout_sec = @as(i64, @intCast(config.pong_timeout_ms)) / 1000;
+            const pong_timeout_sec = @divTrunc(@as(i64, @intCast(config.pong_timeout_ms)), 1000);
             if (now - last_ping > pong_timeout_sec) {
                 self.mutex.lockUncancelable(@import("io.zig").io());
                 self.state = .disconnected;
@@ -480,7 +484,7 @@ pub const Relay = struct {
             }
         }
 
-        const ping_interval_sec = @as(i64, @intCast(config.ping_interval_ms)) / 1000;
+        const ping_interval_sec = @divTrunc(@as(i64, @intCast(config.ping_interval_ms)), 1000);
         if (now - last_msg > ping_interval_sec and !awaiting) {
             self.sendPing() catch {};
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -44,6 +44,8 @@
 //! - `classified_listing.zig` - NIP-99 classified listings
 //! - `nip04.zig` - NIP-04 Encrypted Direct Messages (deprecated)
 
+const std = @import("std");
+
 pub const io = @import("io.zig");
 pub const crypto = @import("crypto.zig");
 pub const http_auth = @import("http_auth.zig");
@@ -135,55 +137,73 @@ pub const stringzilla = @import("stringzilla.zig");
 pub const utils = @import("utils.zig");
 pub const hex = @import("hex.zig");
 
+// Recursively reference every declaration so the compiler analyzes all function
+// bodies, not just the ones with tests. Zig only compiles referenced code, so
+// without this an untested pub fn (e.g. a relay/ws client method) can ship
+// broken; CI runs `zig build test`, which exercises this. (std dropped the
+// recursive variant; this reimplements it for 0.16.)
+fn refAllDeclsRecursive(comptime T: type) void {
+    inline for (comptime std.meta.declarations(T)) |decl| {
+        if (@TypeOf(@field(T, decl.name)) == type) {
+            switch (@typeInfo(@field(T, decl.name))) {
+                .@"struct", .@"enum", .@"union", .@"opaque" => refAllDeclsRecursive(@field(T, decl.name)),
+                else => {},
+            }
+        }
+        _ = &@field(T, decl.name);
+    }
+}
+
 test {
-    _ = @import("http_auth.zig");
-    _ = @import("tags.zig");
-    _ = @import("event.zig");
-    _ = @import("filter.zig");
-    _ = @import("messages.zig");
-    _ = @import("builder.zig");
-    _ = @import("auth.zig");
-    _ = @import("replaceable.zig");
-    _ = @import("index_keys.zig");
-    _ = @import("bech32.zig");
-    _ = @import("relay_metadata.zig");
-    _ = @import("external_identities.zig");
-    _ = @import("relay_groups.zig");
-    _ = @import("pow.zig");
-    _ = @import("negentropy.zig");
-    _ = @import("stringzilla.zig");
-    _ = @import("utils.zig");
-    _ = @import("hex.zig");
-    _ = @import("nwc.zig");
-    _ = @import("crypto.zig");
-    _ = @import("nip17.zig");
-    _ = @import("nip21.zig");
-    _ = @import("nip25.zig");
-    _ = @import("nip27.zig");
-    _ = @import("nip28.zig");
-    _ = @import("nip43.zig");
-    _ = @import("nip46.zig");
-    _ = @import("nip05.zig");
-    _ = @import("nip06.zig");
-    _ = @import("nip10.zig");
-    _ = @import("nip18.zig");
-    _ = @import("nip49.zig");
-    _ = @import("nip57.zig");
-    _ = @import("nip59.zig");
-    _ = @import("nip86.zig");
-    _ = @import("dlc_oracle.zig");
-    _ = @import("clink.zig");
-    _ = @import("joinstr.zig");
-    _ = @import("custom_emoji.zig");
-    _ = @import("ws/ws.zig");
-    _ = @import("message_queue.zig");
-    _ = @import("pool.zig");
-    _ = @import("relay.zig");
-    _ = @import("signer.zig");
-    _ = @import("nip11.zig");
-    _ = @import("badges.zig");
-    _ = @import("zap_goal.zig");
-    _ = @import("file_metadata.zig");
-    _ = @import("classified_listing.zig");
-    _ = @import("nip04.zig");
+    @setEvalBranchQuota(1_000_000);
+    refAllDeclsRecursive(@import("http_auth.zig"));
+    refAllDeclsRecursive(@import("tags.zig"));
+    refAllDeclsRecursive(@import("event.zig"));
+    refAllDeclsRecursive(@import("filter.zig"));
+    refAllDeclsRecursive(@import("messages.zig"));
+    refAllDeclsRecursive(@import("builder.zig"));
+    refAllDeclsRecursive(@import("auth.zig"));
+    refAllDeclsRecursive(@import("replaceable.zig"));
+    refAllDeclsRecursive(@import("index_keys.zig"));
+    refAllDeclsRecursive(@import("bech32.zig"));
+    refAllDeclsRecursive(@import("relay_metadata.zig"));
+    refAllDeclsRecursive(@import("external_identities.zig"));
+    refAllDeclsRecursive(@import("relay_groups.zig"));
+    refAllDeclsRecursive(@import("pow.zig"));
+    refAllDeclsRecursive(@import("negentropy.zig"));
+    refAllDeclsRecursive(@import("stringzilla.zig"));
+    refAllDeclsRecursive(@import("utils.zig"));
+    refAllDeclsRecursive(@import("hex.zig"));
+    refAllDeclsRecursive(@import("nwc.zig"));
+    refAllDeclsRecursive(@import("crypto.zig"));
+    refAllDeclsRecursive(@import("nip17.zig"));
+    refAllDeclsRecursive(@import("nip21.zig"));
+    refAllDeclsRecursive(@import("nip25.zig"));
+    refAllDeclsRecursive(@import("nip27.zig"));
+    refAllDeclsRecursive(@import("nip28.zig"));
+    refAllDeclsRecursive(@import("nip43.zig"));
+    refAllDeclsRecursive(@import("nip46.zig"));
+    refAllDeclsRecursive(@import("nip05.zig"));
+    refAllDeclsRecursive(@import("nip06.zig"));
+    refAllDeclsRecursive(@import("nip10.zig"));
+    refAllDeclsRecursive(@import("nip18.zig"));
+    refAllDeclsRecursive(@import("nip49.zig"));
+    refAllDeclsRecursive(@import("nip57.zig"));
+    refAllDeclsRecursive(@import("nip59.zig"));
+    refAllDeclsRecursive(@import("nip86.zig"));
+    refAllDeclsRecursive(@import("dlc_oracle.zig"));
+    refAllDeclsRecursive(@import("clink.zig"));
+    refAllDeclsRecursive(@import("joinstr.zig"));
+    refAllDeclsRecursive(@import("custom_emoji.zig"));
+    refAllDeclsRecursive(@import("ws/ws.zig"));
+    refAllDeclsRecursive(@import("message_queue.zig"));
+    refAllDeclsRecursive(@import("pool.zig"));
+    refAllDeclsRecursive(@import("relay.zig"));
+    refAllDeclsRecursive(@import("signer.zig"));
+    refAllDeclsRecursive(@import("nip11.zig"));
+    refAllDeclsRecursive(@import("badges.zig"));
+    refAllDeclsRecursive(@import("zap_goal.zig"));
+    refAllDeclsRecursive(@import("file_metadata.zig"));
+    refAllDeclsRecursive(@import("classified_listing.zig"));
+    refAllDeclsRecursive(@import("nip04.zig"));
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -174,6 +174,7 @@ test {
     refAllDeclsRecursive(@import("stringzilla.zig"));
     refAllDeclsRecursive(@import("utils.zig"));
     refAllDeclsRecursive(@import("hex.zig"));
+    refAllDeclsRecursive(@import("io.zig"));
     refAllDeclsRecursive(@import("nwc.zig"));
     refAllDeclsRecursive(@import("crypto.zig"));
     refAllDeclsRecursive(@import("nip17.zig"));


### PR DESCRIPTION
Closes #120.

## Root problem

Zig only compiles *referenced* code. libnostr-z's test in `root.zig` did `_ = @import("x.zig")` for each file, which pulls in those files' `test` blocks but **not** their untested `pub` functions. So whole client modules (`relay.zig`, `ws/`, `pool.zig`) shipped without ever being compiled, and broke under 0.16 unnoticed (see #119, #120). The first downstream consumer to actually call them hit the errors.

## Compile-coverage guard

`root.zig` now references every declaration recursively (`refAllDeclsRecursive`, reimplemented since std dropped the recursive variant), so `zig build test` forces analysis of all function bodies. CI already runs `zig build test`, so this class of breakage is now caught on every push.

Adding the guard immediately surfaced three more latent breakages, all fixed here:
- `pool.zig:716` — `std.ArrayList(Event).init(allocator)` (removed in 0.16) → unmanaged `.empty` + allocator-passing `append`/`deinit`/`toOwnedSlice`.
- `relay.zig:471,487` — `@as(i64, ...) / 1000` → `@divTrunc` (0.16 rejects `/` on signed ints).

## #120 fix (event use-after-free)

`parseRelayMessage` parsed the event from `payload` (a slice `receive()` frees before returning), so `RelayMessage.event`'s `raw_json`/content dangled. It already dupes `payload` into the owned `raw_copy`; the event is now parsed from `raw_copy`, so its borrowed slices live as long as the message.

## Validation

`zig build test` passes (tests run + full compile coverage). A downstream CLI round-trips publish/REQ/tag-filtered-query against a live relay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory management for event handling and resource allocation.
  * Enhanced message parsing logic for better reliability.
  * Updated test infrastructure for more comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->