### PR TITLE
Add NIP-45 COUNT and NIP-11 document fetch to the client

### DIFF
--- a/src/messages.zig
+++ b/src/messages.zig
@@ -419,6 +419,26 @@ pub const ClientMsg = struct {
         return fbs.buffered();
     }
 
+    // NIP-45: ["COUNT", <sub_id>, <filter>...]. Same shape as REQ.
+    pub fn countMsg(sub_id: []const u8, filters: []const Filter, buf: []u8) ![]u8 {
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
+
+        try writer.writeAll("[\"COUNT\",\"");
+        try writer.writeAll(sub_id);
+        try writer.writeByte('"');
+
+        for (filters) |filter| {
+            try writer.writeByte(',');
+            const filter_json = try filter.serialize(buf[fbs.end..]);
+            fbs.end += filter_json.len;
+        }
+
+        try writer.writeAll("]");
+
+        return fbs.buffered();
+    }
+
     pub fn closeMsg(sub_id: []const u8, buf: []u8) ![]u8 {
         var fbs = std.Io.Writer.fixed(buf);
         const writer = &fbs;
@@ -1007,4 +1027,12 @@ test "ClientMsg.getFilters parses multiple filters" {
     try std.testing.expectEqual(@as(i32, 10), filters[0].limit_val);
     try std.testing.expectEqual(@as(i32, 7), filters[1].kinds_slice.?[0]);
     try std.testing.expectEqual(@as(i64, 1700000000), filters[1].since_val);
+}
+
+test "countMsg builds a NIP-45 COUNT request" {
+    var buf: [256]u8 = undefined;
+    const kinds = [_]i32{1};
+    const f = Filter{ .kinds_slice = &kinds };
+    const msg = try ClientMsg.countMsg("s", &.{f}, &buf);
+    try std.testing.expectEqualStrings("[\"COUNT\",\"s\",{\"kinds\":[1]}]", msg);
 }

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -721,14 +721,22 @@ pub fn fetchDocument(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
     var client: std.http.Client = .{ .allocator = allocator, .io = io };
     defer client.deinit();
     if (std.mem.startsWith(u8, http_url, "https://")) {
-        client.ca_bundle.rescan(allocator, io, std.Io.Timestamp.now(io, .awake)) catch {};
+        // Wall-clock time is required: rescan validates certificate validity
+        // periods, which are absolute dates. A monotonic clock would make every
+        // cert appear invalid and silently empty the bundle.
+        try client.ca_bundle.rescan(allocator, io, std.Io.Timestamp.now(io, .real));
     }
 
     var body_buf: [65536]u8 = undefined;
     var body_writer = std.Io.Writer.fixed(&body_buf);
 
+    // std.http.Client.fetch in Zig 0.16 exposes no connect/read timeout; the
+    // only timeout hook is ConnectTcpOptions.timeout on the low-level path.
+    // Disallow redirects: NIP-11 documents are served directly by the relay,
+    // and following redirects would open an SSRF vector to internal hosts.
     const res = try client.fetch(.{
         .location = .{ .url = http_url },
+        .redirect_behavior = .not_allowed,
         .extra_headers = &.{.{ .name = "accept", .value = "application/nostr+json" }},
         .response_writer = &body_writer,
     });
@@ -742,4 +750,5 @@ test toHttpUrl {
     try std.testing.expectEqualStrings("https://relay.example.com", try toHttpUrl("wss://relay.example.com", &buf));
     try std.testing.expectEqualStrings("http://127.0.0.1:7777", try toHttpUrl("ws://127.0.0.1:7777", &buf));
     try std.testing.expectEqualStrings("https://x.com", try toHttpUrl("https://x.com", &buf));
+    try std.testing.expectEqualStrings("https://relay.example.com", try toHttpUrl("relay.example.com", &buf));
 }

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -699,3 +699,47 @@ test "parse fees with string containing braces" {
     try std.testing.expectEqualStrings("msats", adm.unit().?);
     try std.testing.expect(adm_iter.next() == null);
 }
+
+// Convert a relay URL to its NIP-11 HTTP(S) form: ws -> http, wss -> https.
+// http/https pass through; a bare host is assumed https.
+fn toHttpUrl(url: []const u8, buf: []u8) ![]const u8 {
+    if (std.mem.startsWith(u8, url, "wss://")) return std.fmt.bufPrint(buf, "https://{s}", .{url[6..]});
+    if (std.mem.startsWith(u8, url, "ws://")) return std.fmt.bufPrint(buf, "http://{s}", .{url[5..]});
+    if (std.mem.startsWith(u8, url, "http://") or std.mem.startsWith(u8, url, "https://")) return url;
+    return std.fmt.bufPrint(buf, "https://{s}", .{url});
+}
+
+/// Fetch the NIP-11 relay information document over HTTP(S) with
+/// `Accept: application/nostr+json`. Accepts ws/wss or http/https URLs. Returns
+/// the raw JSON body, owned by the caller. Parse it with RelayInformation.parse.
+pub fn fetchDocument(allocator: std.mem.Allocator, url: []const u8) ![]u8 {
+    const io = @import("io.zig").io();
+
+    var url_buf: [2048]u8 = undefined;
+    const http_url = try toHttpUrl(url, &url_buf);
+
+    var client: std.http.Client = .{ .allocator = allocator, .io = io };
+    defer client.deinit();
+    if (std.mem.startsWith(u8, http_url, "https://")) {
+        client.ca_bundle.rescan(allocator, io, std.Io.Timestamp.now(io, .awake)) catch {};
+    }
+
+    var body_buf: [65536]u8 = undefined;
+    var body_writer = std.Io.Writer.fixed(&body_buf);
+
+    const res = try client.fetch(.{
+        .location = .{ .url = http_url },
+        .extra_headers = &.{.{ .name = "accept", .value = "application/nostr+json" }},
+        .response_writer = &body_writer,
+    });
+    if (res.status != .ok) return error.HttpStatus;
+
+    return allocator.dupe(u8, body_writer.buffered());
+}
+
+test toHttpUrl {
+    var buf: [128]u8 = undefined;
+    try std.testing.expectEqualStrings("https://relay.example.com", try toHttpUrl("wss://relay.example.com", &buf));
+    try std.testing.expectEqualStrings("http://127.0.0.1:7777", try toHttpUrl("ws://127.0.0.1:7777", &buf));
+    try std.testing.expectEqualStrings("https://x.com", try toHttpUrl("https://x.com", &buf));
+}

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -289,6 +289,24 @@ pub const Relay = struct {
         }
     }
 
+    // NIP-45: send a COUNT request. The reply arrives via receive() as a
+    // RelayMessage with msg_type == .count and the total in the count field.
+    pub fn count(self: *Self, sub_id: []const u8, filters: []const Filter) !void {
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
+
+        if (self.state != .connected) return RelayError.NotConnected;
+
+        var buf: [8192]u8 = undefined;
+        const msg = try messages.ClientMsg.countMsg(sub_id, filters, &buf);
+
+        if (self.client) |*c| {
+            c.sendText(msg) catch return RelayError.SendFailed;
+        } else {
+            return RelayError.NotConnected;
+        }
+    }
+
     pub fn receive(self: *Self) !?RelayMessage {
         self.mutex.lockUncancelable(@import("io.zig").io());
         if (self.state != .connected) {


### PR DESCRIPTION
Client capabilities needed by downstream tools (a CLI built on this library). Both are exercised by the compile-coverage guard and unit-tested; NIP-11 fetch is verified live against a relay.

## NIP-45 COUNT
- `messages.ClientMsg.countMsg(sub_id, filters, buf)` builds `["COUNT", <id>, <filter>...]` (same shape as REQ).
- `Relay.count(sub_id, filters)` sends it; the reply arrives via `receive()` as a `RelayMessage` with `msg_type == .count` and the total in `count`.

## NIP-11 fetch
- `nip11.fetchDocument(allocator, url)` does an HTTP(S) GET with `Accept: application/nostr+json` and returns the raw JSON body (owned). Accepts ws/wss or http/https URLs (ws->http, wss->https; loads the system CA bundle for https). Parse with `RelayInformation.parse`.

Verified live: fetching against a relay returns a byte-identical document to `curl -H "Accept: application/nostr+json"`.

## Follow-up (not in this PR)
A negentropy (NIP-77) client sync driver (initiate/reconcile loop -> collect have/need -> fetch -> publish, with drain-before-publish) to round out the client. The primitives in `negentropy.zig` exist; tying them into a sync helper is the remaining piece.