### PR TITLE
ws.Client: set TCP_NODELAY to avoid Nagle stalls

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nostr,
-    .version = "0.3.2",
+    .version = "0.3.3",
     .fingerprint = 0x208aa38f708e8e25,
     .dependencies = .{
         .noscrypt = .{

--- a/src/ws/client.zig
+++ b/src/ws/client.zig
@@ -85,6 +85,13 @@ pub const Client = struct {
         const tcp_stream = try host_name.connect(io_mod.io(), parsed.port, .{ .mode = .stream });
         errdefer tcp_stream.close(io_mod.io());
 
+        // Nostr is a small-message, request/response protocol. Without TCP_NODELAY,
+        // Nagle's algorithm holds a write (e.g. a REQ sent right after a CLOSE)
+        // until the prior segment is ACKed, colliding with the peer's delayed ACK
+        // for a ~40ms stall per round-trip. Disable it for low latency.
+        const one = std.mem.toBytes(@as(c_int, 1));
+        std.posix.setsockopt(tcp_stream.socket.handle, std.posix.IPPROTO.TCP, std.posix.TCP.NODELAY, &one) catch {};
+
         var ssl_stream: ?ssl.SslStream = null;
         if (parsed.is_tls) {
             ssl_stream = try ssl.SslStream.init(tcp_stream, parsed.host);


### PR DESCRIPTION
## Problem

`ws.Client` left Nagle's algorithm enabled on the TCP socket. Nostr is a small-message request/response protocol, so a write issued right after another small write (e.g. a `REQ` sent immediately after a `CLOSE`, with no intervening read) is held by Nagle until the prior segment is ACKed. That collides with the peer's delayed ACK for a ~40 ms stall per round-trip.

Measured against a local relay: a REQ/EOSE/CLOSE query loop ran at ~23 queries/s (41.8 ms avg) and jumped to ~483 queries/s (1.0 ms avg) with TCP_NODELAY set. (Surfaced while migrating nostr-bench to this client.)

## Fix

Set `TCP_NODELAY` on the socket right after connecting. Failure to set it is non-fatal (best-effort `catch {}`).

Bumps the package version to 0.3.3.