### PR TITLE
Add NIP-77 negentropy relay-to-relay sync driver

### DIFF
--- a/src/messages.zig
+++ b/src/messages.zig
@@ -449,6 +449,57 @@ pub const ClientMsg = struct {
 
         return fbs.buffered();
     }
+
+    // NIP-77: ["NEG-OPEN", <sub_id>, <filter>, "<hex payload>"]. payload is the
+    // raw negentropy message bytes; it is hex-encoded here.
+    pub fn negOpenMsg(sub_id: []const u8, filter: *const Filter, payload: []const u8, buf: []u8) ![]u8 {
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
+
+        try writer.writeAll("[\"NEG-OPEN\",\"");
+        try writer.writeAll(sub_id);
+        try writer.writeAll("\",");
+
+        const filter_json = try filter.serialize(buf[fbs.end..]);
+        fbs.end += filter_json.len;
+
+        try writer.writeAll(",\"");
+        const hex_len = payload.len * 2;
+        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
+        hex.encode(payload, buf[fbs.end..][0..hex_len]);
+        fbs.end += hex_len;
+        try writer.writeAll("\"]");
+
+        return fbs.buffered();
+    }
+
+    // NIP-77: ["NEG-MSG", <sub_id>, "<hex payload>"].
+    pub fn negMsg(sub_id: []const u8, payload: []const u8, buf: []u8) ![]u8 {
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
+
+        try writer.writeAll("[\"NEG-MSG\",\"");
+        try writer.writeAll(sub_id);
+        try writer.writeAll("\",\"");
+
+        const hex_len = payload.len * 2;
+        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
+        hex.encode(payload, buf[fbs.end..][0..hex_len]);
+        fbs.end += hex_len;
+
+        try writer.writeAll("\"]");
+        return fbs.buffered();
+    }
+
+    // NIP-77: ["NEG-CLOSE", <sub_id>].
+    pub fn negCloseMsg(sub_id: []const u8, buf: []u8) ![]u8 {
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
+        try writer.writeAll("[\"NEG-CLOSE\",\"");
+        try writer.writeAll(sub_id);
+        try writer.writeAll("\"]");
+        return fbs.buffered();
+    }
 };
 
 pub const RelayMsgType = enum {

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -439,15 +439,28 @@ pub const ClientMsg = struct {
         return fbs.buffered();
     }
 
-    pub fn closeMsg(sub_id: []const u8, buf: []u8) ![]u8 {
+    fn singleArgMsg(verb: []const u8, sub_id: []const u8, buf: []u8) ![]u8 {
         var fbs = std.Io.Writer.fixed(buf);
         const writer = &fbs;
 
-        try writer.writeAll("[\"CLOSE\",\"");
+        try writer.writeAll("[\"");
+        try writer.writeAll(verb);
+        try writer.writeAll("\",\"");
         try writer.writeAll(sub_id);
         try writer.writeAll("\"]");
 
         return fbs.buffered();
+    }
+
+    fn writeHexPayload(fbs: *std.Io.Writer, buf: []u8, payload: []const u8) !void {
+        const hex_len = payload.len * 2;
+        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
+        hex.encode(payload, buf[fbs.end..][0..hex_len]);
+        fbs.end += hex_len;
+    }
+
+    pub fn closeMsg(sub_id: []const u8, buf: []u8) ![]u8 {
+        return singleArgMsg("CLOSE", sub_id, buf);
     }
 
     // NIP-77: ["NEG-OPEN", <sub_id>, <filter>, "<hex payload>"]. payload is the
@@ -464,10 +477,7 @@ pub const ClientMsg = struct {
         fbs.end += filter_json.len;
 
         try writer.writeAll(",\"");
-        const hex_len = payload.len * 2;
-        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
-        hex.encode(payload, buf[fbs.end..][0..hex_len]);
-        fbs.end += hex_len;
+        try writeHexPayload(&fbs, buf, payload);
         try writer.writeAll("\"]");
 
         return fbs.buffered();
@@ -482,10 +492,7 @@ pub const ClientMsg = struct {
         try writer.writeAll(sub_id);
         try writer.writeAll("\",\"");
 
-        const hex_len = payload.len * 2;
-        if (fbs.end + hex_len + 2 > buf.len) return error.NoSpaceLeft;
-        hex.encode(payload, buf[fbs.end..][0..hex_len]);
-        fbs.end += hex_len;
+        try writeHexPayload(&fbs, buf, payload);
 
         try writer.writeAll("\"]");
         return fbs.buffered();
@@ -493,12 +500,7 @@ pub const ClientMsg = struct {
 
     // NIP-77: ["NEG-CLOSE", <sub_id>].
     pub fn negCloseMsg(sub_id: []const u8, buf: []u8) ![]u8 {
-        var fbs = std.Io.Writer.fixed(buf);
-        const writer = &fbs;
-        try writer.writeAll("[\"NEG-CLOSE\",\"");
-        try writer.writeAll(sub_id);
-        try writer.writeAll("\"]");
-        return fbs.buffered();
+        return singleArgMsg("NEG-CLOSE", sub_id, buf);
     }
 };
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -79,6 +79,7 @@ pub const ws = @import("ws/ws.zig");
 pub const message_queue = @import("message_queue.zig");
 pub const pool = @import("pool.zig");
 pub const relay = @import("relay.zig");
+pub const sync = @import("sync.zig");
 pub const signer = @import("signer.zig");
 pub const nip11 = @import("nip11.zig");
 pub const badges = @import("badges.zig");
@@ -200,6 +201,7 @@ test {
     refAllDeclsRecursive(@import("message_queue.zig"));
     refAllDeclsRecursive(@import("pool.zig"));
     refAllDeclsRecursive(@import("relay.zig"));
+    refAllDeclsRecursive(@import("sync.zig"));
     refAllDeclsRecursive(@import("signer.zig"));
     refAllDeclsRecursive(@import("nip11.zig"));
     refAllDeclsRecursive(@import("badges.zig"));

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -5,12 +5,13 @@ const ws = @import("ws/ws.zig");
 const negentropy = @import("negentropy.zig");
 const messages = @import("messages.zig");
 const Filter = @import("filter.zig").Filter;
-const hex = @import("hex.zig");
 
 const SUB_ID = "noz-sync";
 const FRAME_LIMIT: u64 = 60000;
 const BUF = 131072;
 const FETCH_BATCH = 200;
+const MAX_ROUNDS = 1024;
+const MAX_NEED = 500_000;
 
 pub const SyncError = error{NegProtocolError};
 
@@ -46,7 +47,11 @@ pub fn syncRelays(
     var need: std.ArrayListUnmanaged([32]u8) = .empty;
     defer need.deinit(allocator);
 
+    var rounds: usize = 0;
     while (true) {
+        rounds += 1;
+        if (rounds > MAX_ROUNDS) return SyncError.NegProtocolError;
+
         var msg = try src.recvMessage();
         defer msg.deinit();
 
@@ -54,16 +59,17 @@ pub fn syncRelays(
         if (std.mem.eql(u8, verb, "NEG-ERR")) return SyncError.NegProtocolError;
         if (!std.mem.eql(u8, verb, "NEG-MSG")) continue;
 
-        const neg_hex = nthQuoted(msg.payload, 3) orelse continue;
-        const qlen = neg_hex.len / 2;
-        if (qlen > query_buf.len) return SyncError.NegProtocolError;
-        hex.decode(neg_hex, query_buf[0..qlen]) catch return SyncError.NegProtocolError;
+        var cm = messages.ClientMsg.parseWithAllocator(msg.payload, allocator) catch return SyncError.NegProtocolError;
+        defer cm.deinit();
+        if (cm.msg_type != .neg_msg) continue;
+        const query = cm.getNegPayload(&query_buf) catch return SyncError.NegProtocolError;
 
-        var result = try neg.reconcile(query_buf[0..qlen], &out_buf, allocator);
+        var result = try neg.reconcile(query, &out_buf, allocator);
         defer result.deinit();
         try need.appendSlice(allocator, result.need_ids.items);
+        if (need.items.len > MAX_NEED) return SyncError.NegProtocolError;
 
-        if (result.done or result.output.len == 0) break;
+        if (result.done) break;
         try src.sendText(try messages.ClientMsg.negMsg(SUB_ID, result.output, &work));
     }
 
@@ -85,12 +91,10 @@ pub fn syncRelays(
         var pbuf: [BUF]u8 = undefined;
         const m = std.fmt.bufPrint(&pbuf, "[\"EVENT\",{s}]", .{ev}) catch continue;
         dst.sendText(m) catch continue;
-        var ok = dst.recvMessage() catch {
-            published += 1;
-            continue;
-        };
-        ok.deinit();
-        published += 1;
+        var ok = dst.recvMessage() catch continue;
+        defer ok.deinit();
+        const parsed = messages.RelayMsgParsed.parse(ok.payload, allocator) catch continue;
+        if (parsed.msg_type == .ok and parsed.success) published += 1;
     }
     return published;
 }
@@ -110,37 +114,36 @@ fn fetchByIds(
         const f = Filter{ .allocator = allocator, .ids_bytes = batch };
         try src.sendText(try messages.ClientMsg.reqMsg("noz-fetch", &.{f}, &req_buf));
 
+        var frames: usize = 0;
         while (true) {
+            frames += 1;
+            if (frames > FETCH_BATCH * 4) return SyncError.NegProtocolError;
             var msg = try src.recvMessage();
             defer msg.deinit();
             const verb = firstQuoted(msg.payload) orelse continue;
             if (std.mem.eql(u8, verb, "EVENT")) {
-                if (eventObject(msg.payload)) |obj| {
-                    try out.append(allocator, try allocator.dupe(u8, obj));
+                if (out.items.len < ids.len) {
+                    if (eventObject(msg.payload)) |obj| {
+                        try out.append(allocator, try allocator.dupe(u8, obj));
+                    }
                 }
             } else if (std.mem.eql(u8, verb, "EOSE") or std.mem.eql(u8, verb, "CLOSED")) {
                 break;
             }
         }
+
+        if (messages.ClientMsg.closeMsg("noz-fetch", &req_buf)) |close| {
+            src.sendText(close) catch {};
+        } else |_| {}
     }
 }
 
 // The first quoted string in a relay message array, i.e. the verb. Negentropy
 // payloads and sub ids contain no escaped quotes, so a plain scan is enough.
 fn firstQuoted(s: []const u8) ?[]const u8 {
-    return nthQuoted(s, 1);
-}
-
-fn nthQuoted(s: []const u8, n: usize) ?[]const u8 {
-    var pos: usize = 0;
-    var count: usize = 0;
-    while (true) {
-        const a = std.mem.indexOfScalarPos(u8, s, pos, '"') orelse return null;
-        const b = std.mem.indexOfScalarPos(u8, s, a + 1, '"') orelse return null;
-        count += 1;
-        if (count == n) return s[a + 1 .. b];
-        pos = b + 1;
-    }
+    const open = std.mem.indexOfScalar(u8, s, '"') orelse return null;
+    const close = std.mem.indexOfScalarPos(u8, s, open + 1, '"') orelse return null;
+    return s[open + 1 .. close];
 }
 
 // The event object out of ["EVENT","sub",{...}]: the outermost {...}, so first
@@ -152,10 +155,9 @@ fn eventObject(s: []const u8) ?[]const u8 {
     return s[start .. stop + 1];
 }
 
-test nthQuoted {
+test firstQuoted {
     const m = "[\"NEG-MSG\",\"sub\",\"61abcd\"]";
     try std.testing.expectEqualStrings("NEG-MSG", firstQuoted(m).?);
-    try std.testing.expectEqualStrings("61abcd", nthQuoted(m, 3).?);
 }
 
 test eventObject {

--- a/src/sync.zig
+++ b/src/sync.zig
@@ -1,0 +1,164 @@
+//! NIP-77 negentropy relay-to-relay sync driver.
+
+const std = @import("std");
+const ws = @import("ws/ws.zig");
+const negentropy = @import("negentropy.zig");
+const messages = @import("messages.zig");
+const Filter = @import("filter.zig").Filter;
+const hex = @import("hex.zig");
+
+const SUB_ID = "noz-sync";
+const FRAME_LIMIT: u64 = 60000;
+const BUF = 131072;
+const FETCH_BATCH = 200;
+
+pub const SyncError = error{NegProtocolError};
+
+/// Reconcile `filter`'s events from `src_url` into `dst_url`. Starting from an
+/// empty local set, every event the source holds surfaces as a "need" during
+/// reconciliation; those are fetched from the source and published to the
+/// destination. Returns the number of events published.
+///
+/// The source is drained fully into memory before any publish to the
+/// destination, so a slow destination cannot stall the source read (and the
+/// source's negentropy/subscription deadlines cannot drop unread events).
+pub fn syncRelays(
+    allocator: std.mem.Allocator,
+    src_url: []const u8,
+    dst_url: []const u8,
+    filter: *const Filter,
+) !usize {
+    var src = try ws.connect(allocator, src_url);
+    defer src.close();
+
+    var storage = negentropy.VectorStorage.init(allocator);
+    defer storage.deinit();
+    storage.seal();
+    var neg = negentropy.Negentropy.init(storage.storage(), FRAME_LIMIT);
+
+    var work: [BUF]u8 = undefined;
+    var out_buf: [BUF]u8 = undefined;
+    var query_buf: [BUF]u8 = undefined;
+
+    const initial = try neg.initiate(&out_buf);
+    try src.sendText(try messages.ClientMsg.negOpenMsg(SUB_ID, filter, initial, &work));
+
+    var need: std.ArrayListUnmanaged([32]u8) = .empty;
+    defer need.deinit(allocator);
+
+    while (true) {
+        var msg = try src.recvMessage();
+        defer msg.deinit();
+
+        const verb = firstQuoted(msg.payload) orelse continue;
+        if (std.mem.eql(u8, verb, "NEG-ERR")) return SyncError.NegProtocolError;
+        if (!std.mem.eql(u8, verb, "NEG-MSG")) continue;
+
+        const neg_hex = nthQuoted(msg.payload, 3) orelse continue;
+        const qlen = neg_hex.len / 2;
+        if (qlen > query_buf.len) return SyncError.NegProtocolError;
+        hex.decode(neg_hex, query_buf[0..qlen]) catch return SyncError.NegProtocolError;
+
+        var result = try neg.reconcile(query_buf[0..qlen], &out_buf, allocator);
+        defer result.deinit();
+        try need.appendSlice(allocator, result.need_ids.items);
+
+        if (result.done or result.output.len == 0) break;
+        try src.sendText(try messages.ClientMsg.negMsg(SUB_ID, result.output, &work));
+    }
+
+    try src.sendText(try messages.ClientMsg.negCloseMsg(SUB_ID, &work));
+
+    // Drain the needed events from src fully, then publish to dst.
+    var events: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer {
+        for (events.items) |e| allocator.free(e);
+        events.deinit(allocator);
+    }
+    try fetchByIds(allocator, &src, need.items, &events);
+
+    var dst = try ws.connect(allocator, dst_url);
+    defer dst.close();
+
+    var published: usize = 0;
+    for (events.items) |ev| {
+        var pbuf: [BUF]u8 = undefined;
+        const m = std.fmt.bufPrint(&pbuf, "[\"EVENT\",{s}]", .{ev}) catch continue;
+        dst.sendText(m) catch continue;
+        var ok = dst.recvMessage() catch {
+            published += 1;
+            continue;
+        };
+        ok.deinit();
+        published += 1;
+    }
+    return published;
+}
+
+fn fetchByIds(
+    allocator: std.mem.Allocator,
+    src: *ws.Client,
+    ids: [][32]u8,
+    out: *std.ArrayListUnmanaged([]const u8),
+) !void {
+    var i: usize = 0;
+    while (i < ids.len) : (i += FETCH_BATCH) {
+        const end = @min(i + FETCH_BATCH, ids.len);
+        const batch = ids[i..end];
+
+        var req_buf: [BUF]u8 = undefined;
+        const f = Filter{ .allocator = allocator, .ids_bytes = batch };
+        try src.sendText(try messages.ClientMsg.reqMsg("noz-fetch", &.{f}, &req_buf));
+
+        while (true) {
+            var msg = try src.recvMessage();
+            defer msg.deinit();
+            const verb = firstQuoted(msg.payload) orelse continue;
+            if (std.mem.eql(u8, verb, "EVENT")) {
+                if (eventObject(msg.payload)) |obj| {
+                    try out.append(allocator, try allocator.dupe(u8, obj));
+                }
+            } else if (std.mem.eql(u8, verb, "EOSE") or std.mem.eql(u8, verb, "CLOSED")) {
+                break;
+            }
+        }
+    }
+}
+
+// The first quoted string in a relay message array, i.e. the verb. Negentropy
+// payloads and sub ids contain no escaped quotes, so a plain scan is enough.
+fn firstQuoted(s: []const u8) ?[]const u8 {
+    return nthQuoted(s, 1);
+}
+
+fn nthQuoted(s: []const u8, n: usize) ?[]const u8 {
+    var pos: usize = 0;
+    var count: usize = 0;
+    while (true) {
+        const a = std.mem.indexOfScalarPos(u8, s, pos, '"') orelse return null;
+        const b = std.mem.indexOfScalarPos(u8, s, a + 1, '"') orelse return null;
+        count += 1;
+        if (count == n) return s[a + 1 .. b];
+        pos = b + 1;
+    }
+}
+
+// The event object out of ["EVENT","sub",{...}]: the outermost {...}, so first
+// brace to last brace is exact even when content contains braces.
+fn eventObject(s: []const u8) ?[]const u8 {
+    const start = std.mem.indexOfScalar(u8, s, '{') orelse return null;
+    const stop = std.mem.lastIndexOfScalar(u8, s, '}') orelse return null;
+    if (stop < start) return null;
+    return s[start .. stop + 1];
+}
+
+test nthQuoted {
+    const m = "[\"NEG-MSG\",\"sub\",\"61abcd\"]";
+    try std.testing.expectEqualStrings("NEG-MSG", firstQuoted(m).?);
+    try std.testing.expectEqualStrings("61abcd", nthQuoted(m, 3).?);
+}
+
+test eventObject {
+    const m = "[\"EVENT\",\"s\",{\"id\":\"x\",\"content\":\"a}b\"}]";
+    try std.testing.expectEqualStrings("{\"id\":\"x\",\"content\":\"a}b\"}", eventObject(m).?);
+}


### PR DESCRIPTION
Completes the client capabilities: a `sync.syncRelays(allocator, src_url, dst_url, filter)` driver that reconciles a filter's events from one relay into another over NIP-77 negentropy. Returns the number of events published.

## How it works
- Starts from an empty local set, so every event the source holds surfaces as a "need" during reconciliation.
- `initiate` -> NEG-OPEN; loop NEG-MSG <-> `reconcile`, accumulating need-ids, until done.
- NEG-CLOSE, then fetch the needed ids from the source (batched REQ).
- **Drains the source fully into memory before publishing to the destination**, so a slow destination can't stall the source read and the source's reconciliation/subscription deadlines can't drop unread events (the failure mode behind the nak-sync data loss).

## Supporting additions
- `ClientMsg.negOpenMsg` / `negMsg` / `negCloseMsg` (client NIP-77 message builders; `RelayMsg.negMsg` stays for relay-side use).
- `sync.zig` registered in root + the compile-coverage test.

## Verified live
Two wisp relays: seeded source with 5 events, empty destination; `sync` reported "synced 5 events" and the destination then held all 5. Exercises a real relay's NEG-OPEN/NEG-MSG handling.