### PR TITLE
Add NIP-42 client auth (Relay.authenticate + ClientMsg.authMsg)

### DIFF
--- a/src/messages.zig
+++ b/src/messages.zig
@@ -1102,3 +1102,15 @@ test "countMsg builds a NIP-45 COUNT request" {
     const msg = try ClientMsg.countMsg("s", &.{f}, &buf);
     try std.testing.expectEqualStrings("[\"COUNT\",\"s\",{\"kinds\":[1]}]", msg);
 }
+
+test "authMsg builds a NIP-42 AUTH request" {
+    const json =
+        \\{"id":"0000000000000000000000000000000000000000000000000000000000000001","pubkey":"0000000000000000000000000000000000000000000000000000000000000002","sig":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003","kind":22242,"created_at":1700000000,"content":"","tags":[["relay","wss://relay.example.com"],["challenge","challenge-string"]]}
+    ;
+    var event = try Event.parseWithAllocator(json, std.testing.allocator);
+    defer event.deinit();
+
+    var buf: [1024]u8 = undefined;
+    const msg = try ClientMsg.authMsg(&event, &buf);
+    try std.testing.expectEqualStrings("[\"AUTH\"," ++ json ++ "]", msg);
+}

--- a/src/messages.zig
+++ b/src/messages.zig
@@ -400,6 +400,19 @@ pub const ClientMsg = struct {
         return fbs.buffered();
     }
 
+    // NIP-42: ["AUTH", <signed kind-22242 event>].
+    pub fn authMsg(ev: *const Event, buf: []u8) ![]u8 {
+        var fbs = std.Io.Writer.fixed(buf);
+        const writer = &fbs;
+
+        try writer.writeAll("[\"AUTH\",");
+        const event_json = try ev.serialize(buf[fbs.end..]);
+        fbs.end += event_json.len;
+        try writer.writeAll("]");
+
+        return fbs.buffered();
+    }
+
     pub fn reqMsg(sub_id: []const u8, filters: []const Filter, buf: []u8) ![]u8 {
         var fbs = std.Io.Writer.fixed(buf);
         const writer = &fbs;

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -701,6 +701,13 @@ test "Relay operations when disconnected" {
     var filters = [_]Filter{.{}};
     try std.testing.expectError(RelayError.NotConnected, relay.subscribe("sub1", &filters));
     try std.testing.expectError(RelayError.NotConnected, relay.unsubscribe("sub1"));
+
+    const json =
+        \\{"id":"0000000000000000000000000000000000000000000000000000000000000001","pubkey":"0000000000000000000000000000000000000000000000000000000000000002","sig":"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003","kind":22242,"created_at":1700000000,"content":"","tags":[]}
+    ;
+    var ev = try Event.parseWithAllocator(json, allocator);
+    defer ev.deinit();
+    try std.testing.expectError(RelayError.NotConnected, relay.authenticate(&ev));
 }
 
 test "Subscription struct" {

--- a/src/relay.zig
+++ b/src/relay.zig
@@ -289,6 +289,24 @@ pub const Relay = struct {
         }
     }
 
+    // NIP-42: send an AUTH event (a signed kind-22242 event) in response to the
+    // relay's AUTH challenge.
+    pub fn authenticate(self: *Self, event: *const Event) !void {
+        self.mutex.lockUncancelable(@import("io.zig").io());
+        defer self.mutex.unlock(@import("io.zig").io());
+
+        if (self.state != .connected) return RelayError.NotConnected;
+
+        var buf: [65536]u8 = undefined;
+        const msg = try messages.ClientMsg.authMsg(event, &buf);
+
+        if (self.client) |*c| {
+            c.sendText(msg) catch return RelayError.SendFailed;
+        } else {
+            return RelayError.NotConnected;
+        }
+    }
+
     // NIP-45: send a COUNT request. The reply arrives via receive() as a
     // RelayMessage with msg_type == .count and the total in the count field.
     pub fn count(self: *Self, sub_id: []const u8, filters: []const Filter) !void {


### PR DESCRIPTION
Adds the client side of NIP-42 so a downstream CLI can authenticate to a relay:
- `ClientMsg.authMsg(event, buf)` builds `["AUTH", <signed kind-22242 event>]`.
- `Relay.authenticate(event)` sends it (mirrors `publish`).

The relay already surfaces the AUTH challenge via `RelayMessage` (msg_type `.auth`, challenge in `subscription_id`), so a client reads the challenge, signs a kind-22242 event binding the challenge + relay URL, and calls `authenticate`.

Verified live: a CLI built on this authenticates against a relay requiring auth, and re-publishes a NIP-70 protected event after an auth-required rejection. Covered by the compile-coverage guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIP-42 authentication protocol support, enabling secure client authentication with relay servers through signed authentication events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->