### PR TITLE
Bump version to 0.3.5

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nostr,
-    .version = "0.3.4",
+    .version = "0.3.5",
     .fingerprint = 0x208aa38f708e8e25,
     .dependencies = .{
         .noscrypt = .{


### PR DESCRIPTION
Version field bump to match the v0.3.5 release tag (NIP-42 client auth, #131).