### PR TITLE
Add noz to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ _ = try pool.connectAll();
 
 - [wisp](https://github.com/privkeyio/wisp) - Fast, lightweight nostr relay
 - [nostr-bench](https://github.com/privkeyio/nostr-bench) - Nostr relay benchmark tool
+- [noz](https://github.com/privkeyio/noz) - Small, fast Nostr command-line tool
 - [puck](https://github.com/privkeyio/puck) - NIP-47 Wallet Connect server with LNbits backend
 
 ## License


### PR DESCRIPTION
Add [noz](https://github.com/privkeyio/noz), a small, fast Nostr command-line tool built on libnostr-z, to the Projects Using libnostr-z list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new project entry to the projects using libnostr-z list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->