### PR TITLE
ws: preserve frames bundled with the handshake 101 response

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .nostr,
-    .version = "0.3.5",
+    .version = "0.3.6",
     .fingerprint = 0x208aa38f708e8e25,
     .dependencies = .{
         .noscrypt = .{

--- a/src/ws/client.zig
+++ b/src/ws/client.zig
@@ -61,6 +61,13 @@ pub const Client = struct {
     ws_options: Options,
     is_tls: bool,
     uri: []const u8,
+    /// Bytes read past the HTTP 101 upgrade response. A relay may send its first
+    /// frame (e.g. a NIP-42 AUTH challenge) in the same TCP segment as the upgrade
+    /// response; without preserving this tail the frame is silently dropped and a
+    /// publish that depends on it hangs until the read timeout. Drained before the
+    /// socket on the next read.
+    overflow: []u8 = &.{},
+    overflow_pos: usize = 0,
 
     const Self = @This();
 
@@ -114,6 +121,11 @@ pub const Client = struct {
     }
 
     fn closeResources(self: *Self) void {
+        if (self.overflow.len > 0) {
+            self.allocator.free(self.overflow);
+            self.overflow = &.{};
+            self.overflow_pos = 0;
+        }
         if (self.ssl_stream) |*s| {
             s.close();
         } else {
@@ -136,13 +148,17 @@ pub const Client = struct {
             if (n == 0) return error.ConnectionResetByPeer;
             response_len += n;
 
-            const rsp, _ = handshake.Rsp.parse(response_buf[0..response_len]) catch |err| switch (err) {
+            const rsp, const head_end = handshake.Rsp.parse(response_buf[0..response_len]) catch |err| switch (err) {
                 error.SplitBuffer => continue,
                 else => return err,
             };
 
             try rsp.validate(&sec_key);
             self.ws_options = rsp.options;
+            // Preserve any frame bytes that arrived bundled with the 101 response.
+            if (response_len > head_end) {
+                self.overflow = try self.allocator.dupe(u8, response_buf[head_end..response_len]);
+            }
             return;
         }
 
@@ -197,6 +213,18 @@ pub const Client = struct {
     /// mid-read surfaces as ConnectionResetByPeer.
     fn readExact(self: *Self, buf: []u8) !void {
         var total: usize = 0;
+        // Drain bytes captured past the handshake response before reading the socket.
+        if (self.overflow_pos < self.overflow.len) {
+            const take = @min(self.overflow.len - self.overflow_pos, buf.len);
+            @memcpy(buf[0..take], self.overflow[self.overflow_pos .. self.overflow_pos + take]);
+            self.overflow_pos += take;
+            total = take;
+            if (self.overflow_pos == self.overflow.len) {
+                self.allocator.free(self.overflow);
+                self.overflow = &.{};
+                self.overflow_pos = 0;
+            }
+        }
         while (total < buf.len) {
             const n = try self.read(buf[total..]);
             if (n == 0) return error.ConnectionResetByPeer;


### PR DESCRIPTION
## Problem

The WebSocket client's handshake discards any bytes read past the HTTP `101 Switching Protocols` response. When a relay sends its first frame in the same TCP segment as the upgrade response, that frame is silently dropped.

In `ws/client.zig`, `doHandshake` read up to 4096 bytes into a stack buffer, parsed the 101, and returned — throwing away `response_buf[head_end..]` (the leftover offset was discarded as `_`). The subsequent `recvMessage` then reads the *next* frame off the socket, so the first frame is lost.

This is timing/load dependent: it only triggers when the server's first frame arrives bundled with the 101.

## Impact

Hits any flow that depends on a server-initiated first frame. Concretely: a NIP-42 `auth-required` relay sends the AUTH challenge proactively on connect. Under load it arrives bundled with the 101, gets dropped, the client never sees the challenge, its next read times out (`WouldBlock`), and the authenticated publish fails. Reproduced at ~10-17% failure under contention; **0 failures after this fix** (120 publishes under a CPU hog, 50 full auth integration-test runs on 2 cores).

## Fix

Preserve the post-101 tail in a small per-connection `overflow` buffer and drain it in `readExact` before reading the socket; free it on close.

- `connect`/`doHandshake`: capture `head_end` from `Rsp.parse` and `dupe` the leftover bytes.
- `readExact`: serve from `overflow` first, then the socket.
- `closeResources`: free `overflow`.

No API change. `zig build` + `zig build test` pass.