### PR TITLE
ws: fix receive() dropping handshake-overflow state (re-release v0.3.6)

### DIFF
--- a/src/relay.zig
+++ b/src/relay.zig
@@ -331,10 +331,15 @@ pub const Relay = struct {
             self.mutex.unlock(@import("io.zig").io());
             return RelayError.NotConnected;
         }
-        var client = self.client orelse {
+        if (self.client == null) {
             self.mutex.unlock(@import("io.zig").io());
             return RelayError.NotConnected;
-        };
+        }
+        // Operate on the stored client by pointer, not a copy: recvMessage advances
+        // per-connection read state (the post-handshake overflow buffer) that must
+        // persist across receive() calls. A copy would discard it and re-serve the
+        // buffered first frame on every call. (The send paths already use `|*c|`.)
+        const client = &self.client.?;
         self.mutex.unlock(@import("io.zig").io());
 
         const ws_msg = client.recvMessage() catch |err| {


### PR DESCRIPTION
v0.3.6 (#134) added a per-connection overflow buffer to preserve frames that arrive bundled with the 101 handshake response, drained by recvMessage. But `Relay.receive()` ran recvMessage on a copy of the client (`var client = self.client`), so the drain state (overflow position, free-on-empty) was discarded. Every receive() re-served the buffered first frame, an infinite re-read under load.

Symptom: against an auth-required relay under load, the NIP-42 AUTH challenge (sent bundled with the 101) was read in a loop and the publish never completed.

Fix: receive() operates on the stored client by pointer (`&self.client.?`) so read-state mutations persist across calls. The send paths already use `|*c|`; this aligns receive() with them. The old copy gave no real safety against a concurrent close anyway (it shallow-copies the ssl pointer and fd).

Keeps the version at 0.3.6: this is a re-release, since the original v0.3.6 is broken and unused.

Validated: 0 re-read floods and 0 lost AUTH challenges across 500+ authed publishes on a warmed relay (the broken v0.3.6 reproduced the flood readily under load). zig build and zig build test pass.